### PR TITLE
polar tier enforcement

### DIFF
--- a/apps/app/src/actions/automations.ts
+++ b/apps/app/src/actions/automations.ts
@@ -9,6 +9,7 @@ import {
 import { and, eq, desc, gt, isNull, or, ne } from "drizzle-orm";
 import { getUser, getRLSDb } from "@/lib/auth-utils";
 import { revalidatePath } from "next/cache";
+import { assertBillingAllowed } from "@/lib/billing/enforce";
 
 export type Automation = {
   id: string;
@@ -125,6 +126,8 @@ export async function createAutomation(
     throw new Error("Unauthorized");
   }
 
+  await assertBillingAllowed(user.id, "automation:create");
+
   if (!data.triggerWord || data.triggerWord.trim().length === 0) {
     throw new Error("Trigger word is required");
   }
@@ -205,6 +208,8 @@ export async function updateAutomation(
   if (!user) {
     throw new Error("Unauthorized");
   }
+
+  await assertBillingAllowed(user.id, "automation:mutate");
 
   const existing = await getAutomation(id);
   if (!existing) {
@@ -307,6 +312,8 @@ export async function deleteAutomation(id: string): Promise<void> {
   if (!user) {
     throw new Error("Unauthorized");
   }
+
+  await assertBillingAllowed(user.id, "automation:mutate");
 
   const existing = await getAutomation(id);
   if (!existing) {

--- a/apps/app/src/actions/billing.ts
+++ b/apps/app/src/actions/billing.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { getUser } from "@/lib/auth-utils";
+import { getBillingStatus } from "@/lib/billing/enforce";
+
+export async function getCurrentBillingStatusAction() {
+  const user = await getUser();
+  if (!user) {
+    return null;
+  }
+
+  return getBillingStatus(user.id);
+}

--- a/apps/app/src/actions/contacts.ts
+++ b/apps/app/src/actions/contacts.ts
@@ -600,7 +600,15 @@ export async function syncInstagramContacts(fullSync?: boolean) {
   }
 
   try {
-    await assertBillingAllowed(user.id, "contact:mutate");
+    const db = await getRLSDb();
+    const integration = await db.query.instagramIntegration.findFirst({
+      where: eq(instagramIntegration.userId, user.id),
+    });
+
+    if (!integration) {
+      return { success: false, error: "Instagram is not connected" };
+    }
+
     console.log("Triggering contact sync for user:", user.id);
     await inngest.send({
       name: "contacts/sync",

--- a/apps/app/src/actions/contacts.ts
+++ b/apps/app/src/actions/contacts.ts
@@ -30,6 +30,7 @@ import {
   getPersonalizedLeadAnalysisPrompt,
 } from "@pilot/core/sidekick/personalization";
 import { sanitizeText } from "@/lib/utils";
+import { assertBillingAllowed, BillingLimitError } from "@/lib/billing/enforce";
 import {
   fetchConversationMessagesForSync as fetchInstagramConversationMessagesForSync,
   fetchConversationsForSync as fetchInstagramConversationsForSync,
@@ -206,6 +207,8 @@ async function updateContactField(
       return { success: false, error: "Not authenticated" };
     }
 
+    await assertBillingAllowed(user.id, "contact:mutate");
+
     const db = await getRLSDb();
     const existingContact = await db.query.contact.findFirst({
       where: and(eq(contact.id, contactId), eq(contact.userId, user.id)),
@@ -229,6 +232,10 @@ async function updateContactField(
     revalidatePath("/contacts");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error(`Error updating contact ${field}:`, error);
     return { success: false, error: `Failed to update contact ${field}` };
   }
@@ -262,6 +269,8 @@ export async function updateContactHRNState(
       return { success: false, error: "Not authenticated" };
     }
 
+    await assertBillingAllowed(user.id, "contact:mutate");
+
     const db = await getRLSDb();
     const existingContact = await db.query.contact.findFirst({
       where: and(eq(contact.id, contactId), eq(contact.userId, user.id)),
@@ -286,6 +295,10 @@ export async function updateContactHRNState(
     revalidatePath("/contacts");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("Error updating HRN state:", error);
     return { success: false, error: "Failed to update HRN state" };
   }
@@ -300,6 +313,8 @@ export async function updateContactFollowUpStatus(
     if (!user) {
       return { success: false, error: "Not authenticated" };
     }
+
+    await assertBillingAllowed(user.id, "contact:mutate");
 
     const db = await getRLSDb();
     const existingContact = await db.query.contact.findFirst({
@@ -321,6 +336,10 @@ export async function updateContactFollowUpStatus(
     revalidatePath("/contacts");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("Error updating contact follow-up status:", error);
     return {
       success: false,
@@ -345,6 +364,8 @@ export async function updateContactAfterFollowUp(
       return { success: false, error: "Not authenticated" };
     }
 
+    await assertBillingAllowed(user.id, "contact:mutate");
+
     const db = await getRLSDb();
     const existingContact = await db.query.contact.findFirst({
       where: and(eq(contact.id, contactId), eq(contact.userId, user.id)),
@@ -366,6 +387,10 @@ export async function updateContactAfterFollowUp(
     revalidatePath("/contacts");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("Error updating contact after follow-up:", error);
     return {
       success: false,
@@ -380,6 +405,8 @@ export async function addContactTagAction(contactId: string, tag: string) {
     if (!user) {
       return { success: false, error: "Not authenticated" };
     }
+
+    await assertBillingAllowed(user.id, "contact:mutate");
 
     const db = await getRLSDb();
     const existing = await db.query.contact.findFirst({
@@ -425,6 +452,10 @@ export async function addContactTagAction(contactId: string, tag: string) {
     revalidateTag(`user-tags-${user.id}`, "max");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("addContactTagAction error:", error);
     return { success: false, error: "Failed to add tag" };
   }
@@ -436,6 +467,8 @@ export async function removeContactTagAction(contactId: string, tag: string) {
     if (!user) {
       return { success: false, error: "Not authenticated" };
     }
+
+    await assertBillingAllowed(user.id, "contact:mutate");
 
     const db = await getRLSDb();
     const existing = await db.query.contact.findFirst({
@@ -461,6 +494,10 @@ export async function removeContactTagAction(contactId: string, tag: string) {
     revalidateTag(`user-tags-${user.id}`, "max");
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("removeContactTagAction error:", error);
     return { success: false, error: "Failed to remove tag" };
   }
@@ -563,6 +600,7 @@ export async function syncInstagramContacts(fullSync?: boolean) {
   }
 
   try {
+    await assertBillingAllowed(user.id, "contact:mutate");
     console.log("Triggering contact sync for user:", user.id);
     await inngest.send({
       name: "contacts/sync",
@@ -579,6 +617,10 @@ export async function syncInstagramContacts(fullSync?: boolean) {
 
     return { success: true };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("Error triggering contact sync:", error);
     return {
       success: false,
@@ -1237,6 +1279,8 @@ export async function generateFollowUpMessage(contactId: string) {
       return { success: false, error: "Not authenticated" };
     }
 
+    await assertBillingAllowed(user.id, "contact:mutate");
+
     const db = await getRLSDb();
     const contactData = await db.query.contact.findFirst({
       where: and(eq(contact.id, contactId), eq(contact.userId, user.id)),
@@ -1312,6 +1356,10 @@ export async function generateFollowUpMessage(contactId: string) {
     revalidatePath("/contacts");
     return { success: true, message: followUpText };
   } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return { success: false, error: error.message };
+    }
+
     console.error("Error generating follow-up message:", error);
     return { success: false, error: "Failed to generate follow-up message" };
   }

--- a/apps/app/src/actions/sidekick/ai-tools/user-profile.ts
+++ b/apps/app/src/actions/sidekick/ai-tools/user-profile.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import { getUser, getRLSDb } from "@/lib/auth-utils";
 import { user } from "@pilot/db/schema";
 import { eq } from "drizzle-orm";
+import { getBillingStatus } from "@/lib/billing/enforce";
+import { getPricingPlan } from "@/lib/constants/pricing";
 
 const updateUserProfileSchema = z.object({
   name: z
@@ -54,6 +56,15 @@ export async function getUserProfile() {
       return { success: false, error: "User profile not found" };
     }
 
+    const billingStatus = await getBillingStatus(currentUser.id);
+    const currentPlan = getPricingPlan(billingStatus.planId);
+    const quotaExceeded =
+      billingStatus.flags.isStructurallyFrozen ||
+      !billingStatus.flags.canCreateContact ||
+      !billingStatus.flags.canCreateAutomation ||
+      !billingStatus.flags.canUseSidekickChat ||
+      !billingStatus.flags.canSendSidekickReply;
+
     return {
       success: true,
       profile: {
@@ -63,6 +74,13 @@ export async function getUserProfile() {
         use_case: userProfile.use_case,
         business_type: userProfile.business_type,
         main_offering: userProfile.main_offering,
+        quota: {
+          planId: billingStatus.planId,
+          planName: currentPlan.title,
+          exceeded: quotaExceeded,
+          usage: billingStatus.usage,
+          limits: billingStatus.limits,
+        },
       },
     };
   } catch (error) {

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -20,7 +20,10 @@ import {
 import { useEffect, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { handleCheckout } from "@/lib/polar/client";
-import PlanBadge, { getSubscriptionData } from "@/components/subscription-badge";
+import PlanBadge, {
+  getSubscriptionData,
+} from "@/components/subscription-badge";
+import Link from "next/link";
 
 export default function UpgradePage() {
   const [isYearly, setIsYearly] = useState(false);
@@ -50,7 +53,7 @@ export default function UpgradePage() {
 
   return (
     <section className="bg-background @container">
-      <div className="mx-auto max-w-7xl px-6 py-10 md:py-16 lg:py-24">
+      <div className="mx-auto max-w-[110rem] px-6 py-10 md:py-16 lg:py-24">
         <PlanBadge />
 
         <div className="mx-auto max-w-2xl text-center">
@@ -97,14 +100,18 @@ export default function UpgradePage() {
                 className="absolute z-0 rounded-full bg-primary"
                 initial={false}
                 animate={{ x: isYearly ? 120 : 0 }}
-                transition={shouldReduceMotion ? { duration: 0 } : { type: "spring", stiffness: 300, damping: 30 }}
+                transition={
+                  shouldReduceMotion
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 300, damping: 30 }
+                }
                 style={{ width: isYearly ? 180 : 120, height: "100%" }}
               />
             </div>
           </div>
         )}
 
-        <div className="@xl:grid-cols-2 @4xl:grid-cols-4 mt-12 grid gap-4">
+        <div className="@xl:grid-cols-2 @5xl:grid-cols-3 @7xl:grid-cols-5 mt-12 grid gap-4">
           {pricingPlans.map((plan) => {
             const isBestValue = plan.planId === "growth";
             const checkoutConfig = isPaidPlanId(plan.planId)
@@ -189,7 +196,11 @@ export default function UpgradePage() {
                         <ArrowRight className="size-4" />
                       </Button>
                     ) : (
-                      <Button className="w-full gap-2" variant="outline" disabled>
+                      <Button
+                        className="w-full gap-2"
+                        variant="outline"
+                        disabled
+                      >
                         Start on free
                       </Button>
                     )}
@@ -198,11 +209,75 @@ export default function UpgradePage() {
               </Card>
             );
           })}
+
+          <Card className="relative flex h-full flex-col border p-0 bg-card">
+            <CardHeader className="px-6 pt-6 pb-0">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle className="text-lg font-medium">
+                  Enterprise
+                </CardTitle>
+              </div>
+              <p className="text-muted-foreground mt-1 text-sm">
+                For teams that need custom infrastructure and support.
+              </p>
+              <div className="mt-5">
+                <span className="text-4xl font-semibold md:text-5xl">
+                  Custom
+                </span>
+              </div>
+            </CardHeader>
+
+            <CardContent className="flex flex-1 flex-col px-6 pt-6 pb-6">
+              <ul role="list" className="space-y-3">
+                {[
+                  "Unlimited contacts",
+                  "Dedicated infrastructure",
+                  "SLA",
+                  "Custom integrations",
+                  "Self-host support",
+                ].map((feature) => (
+                  <li
+                    key={feature}
+                    className="text-muted-foreground flex items-center gap-2 text-sm"
+                  >
+                    <Check className="text-primary size-4" />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-auto pt-8">
+                <p className="text-muted-foreground mb-4 text-center text-sm">
+                  Contact
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                  <Button className="w-full gap-2" variant="outline" asChild>
+                    <Link
+                      href="https://www.instagram.com/pilot.ops/"
+                      target="_blank"
+                    >
+                      Instagram
+                      <ArrowRight className="size-4" />
+                    </Link>
+                  </Button>
+                  <Button className="w-full gap-2" variant="outline" asChild>
+                    <Link
+                      href="https://x.com/PilotOps_"
+                      target="_blank"
+                    >
+                      X
+                      <ArrowRight className="size-4" />
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
         </div>
 
         <p className="text-muted-foreground mt-8 text-center text-sm">
-          No free trials. You stay on the built-in Free tier until you decide
-          to upgrade.
+          No free trials. You stay on the built-in Free tier until you decide to
+          upgrade.
         </p>
       </div>
     </section>

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { Button } from "@pilot/ui/components/button";
-import { Check } from "lucide-react";
-import { Card, CardHeader, CardTitle } from "@pilot/ui/components/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@pilot/ui/components/card";
+import { ArrowRight, Check } from "lucide-react";
 import {
   type PaidPlanId,
   formatPlanPrice,
@@ -14,35 +19,38 @@ import { useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { handleCheckout } from "@/lib/polar/client";
 import PlanBadge from "@/components/subscription-badge";
+
 export default function UpgradePage() {
   const [isYearly, setIsYearly] = useState(false);
   const shouldReduceMotion = useReducedMotion();
   const showYearlyToggle = hasAnyYearlyPricing();
 
   return (
-    <div className="relative my-auto">
-      <div className="mx-auto max-w-360 px-6">
+    <section className="bg-background @container">
+      <div className="mx-auto max-w-7xl px-6 py-10 md:py-16 lg:py-24">
         <PlanBadge />
 
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-balance text-3xl font-bold font-heading md:text-4xl lg:text-5xl mt-3">
+          <h2 className="mt-3 text-balance font-heading text-3xl font-bold md:text-4xl lg:text-5xl">
             Pick a plan that fits your volume
           </h2>
-          <p className="text-muted-foreground mx-auto mt-4 max-w-xl text-balance text-lg">
-            Start simple, then upgrade when you need more power. No setup fee.
+          <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-balance text-base md:text-lg">
+            Start simple, then upgrade when you need more capacity. Limits are
+            enforced by tier, and you can update the quota values in code
+            whenever you want.
           </p>
         </div>
 
         {showYearlyToggle && (
           <div className="mt-10 flex items-center justify-center">
             <div
-              className="relative flex w-[260px] items-center justify-between rounded-full border bg-muted"
+              className="relative flex w-65 items-center justify-between rounded-full border bg-muted"
               role="radiogroup"
               aria-label="Billing frequency"
             >
               <button
                 onClick={() => setIsYearly(false)}
-                className="relative z-10 w-[130px] py-3 px-6 text-center text-sm font-medium"
+                className="relative z-10 w-65 py-3 px-6 text-center text-sm font-medium"
                 role="radio"
                 aria-checked={!isYearly}
                 aria-label="Monthly billing"
@@ -51,7 +59,7 @@ export default function UpgradePage() {
               </button>
               <button
                 onClick={() => setIsYearly(true)}
-                className="relative z-10 w-[130px] py-3 px-6 text-center text-sm font-medium"
+                className="relative z-10 w-65 py-3 px-6 text-center text-sm font-medium"
                 role="radio"
                 aria-checked={isYearly}
                 aria-label="Yearly billing"
@@ -73,85 +81,94 @@ export default function UpgradePage() {
           </div>
         )}
 
-        <div className="@container relative mt-10">
-          <Card className="@4xl:max-w-full relative mx-auto max-w-sm p-0 border-l-0">
-            <div className="@4xl:grid-cols-4 grid">
-              {pricingPlans.map((plan) => (
-                <div
-                  key={plan.title}
-                  className={
-                    plan.highlighted
-                      ? "ring-foreground/10 bg-background rounded-(--radius) @3xl:mx-0 @3xl:-my-3 -mx-1 border-transparent shadow ring-1"
-                      : ""
-                  }
-                >
-                  <div
-                    className={
-                      plan.highlighted
-                        ? "@3xl:py-3 @3xl:px-0 relative px-1"
-                        : ""
-                    }
-                  >
-                    <CardHeader className="p-8">
-                      <CardTitle className="font-medium text-lg">
-                        {plan.title}
-                      </CardTitle>
-                      <p className="text-muted-foreground mt-2 text-base">
-                        {plan.description}
-                      </p>
-                      <span className="mb-0.5 mt-4 block text-3xl font-semibold">
-                        {formatPlanPrice(plan, isYearly)}
-                        <span className="text-muted-foreground text-base font-normal ml-1">
-                          / month
-                        </span>
-                      </span>
-                      {showYearlyToggle && isYearly && (
-                        <p className="text-xs text-muted-foreground mt-1">
-                          Billed annually
-                        </p>
-                      )}
-                    </CardHeader>
-                    <div
-                      className={`${plan.highlighted ? "@3xl:mx-0 -mx-1 " : ""
-                        }border-y px-8 py-4`}
-                    >
-                      {isPaidPlanId(plan.planId) ? (
-                        <Button
-                          className="w-full"
-                          onClick={async () => {
-                            await handleCheckout(
-                              plan.planId as PaidPlanId,
-                              isYearly
-                            );
-                          }}
-                        >
-                          Subscribe
-                        </Button>
-                      ) : (
-                        <Button className="w-full" variant="outline" disabled>
-                          Current free tier
-                        </Button>
-                      )}
-                    </div>
+        <div className="@xl:grid-cols-2 @4xl:grid-cols-4 mt-12 grid gap-4">
+          {pricingPlans.map((plan) => {
+            const isBestValue = plan.planId === "growth";
 
-                    <ul role="list" className="space-y-3 p-8">
-                      {plan.features.map((feature, index) => (
-                        <li key={index} className="flex items-center gap-2">
-                          <Check
-                            className="text-primary size-3"
-                            strokeWidth={3.5}
-                          />
-                          {feature}
-                        </li>
-                      ))}
-                    </ul>
+            return (
+              <Card
+                key={plan.planId}
+                className={[
+                  "relative flex h-full flex-col border p-0",
+                  isBestValue
+                    ? "border-primary shadow-lg ring-1 ring-primary/20"
+                    : "bg-card",
+                ].join(" ")}
+              >
+                <CardHeader className="px-6 pt-6 pb-0">
+                  <div className="flex items-center justify-between gap-3">
+                    <CardTitle className="text-lg font-medium">
+                      {plan.title}
+                    </CardTitle>
+                    {isBestValue ? (
+                      <span className="rounded-full bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground">
+                        Best Value
+                      </span>
+                    ) : null}
                   </div>
-                </div>
-              ))}
-            </div>
-          </Card>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    {plan.description}
+                  </p>
+                  <div className="mt-5">
+                    <span className="text-4xl font-semibold md:text-5xl">
+                      {formatPlanPrice(plan, isYearly)}
+                    </span>
+                    <span className="text-muted-foreground ml-1 text-sm">
+                      / month
+                    </span>
+                  </div>
+                  {showYearlyToggle && isYearly ? (
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      Billed annually
+                    </p>
+                  ) : null}
+                </CardHeader>
+
+                <CardContent className="flex flex-1 flex-col px-6 pt-6 pb-6">
+                  <ul role="list" className="space-y-3">
+                    {plan.features.map((feature) => (
+                      <li
+                        key={feature}
+                        className="text-muted-foreground flex items-center gap-2 text-sm"
+                      >
+                        <Check className="text-primary size-4" />
+                        {feature}
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div className="mt-auto pt-8">
+                    {isPaidPlanId(plan.planId) ? (
+                      <Button
+                        className="w-full gap-2"
+                        variant={isBestValue ? "default" : "outline"}
+                        onClick={async () => {
+                          await handleCheckout(
+                            plan.planId as PaidPlanId,
+                            isYearly,
+                          );
+                        }}
+                      >
+                        Subscribe
+                        <ArrowRight className="size-4" />
+                      </Button>
+                    ) : (
+                      <Button className="w-full" variant="outline" disabled>
+                        Current free tier
+                      </Button>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
+
+        <p className="text-muted-foreground mt-8 text-center text-sm">
+          No free trials. Free access stays on the built-in free tier until you
+          subscribe.
+        </p>
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -11,6 +11,7 @@ import { ArrowRight, Check } from "lucide-react";
 import {
   type PaidPlanId,
   formatPlanPrice,
+  getCheckoutConfig,
   hasAnyYearlyPricing,
   isPaidPlanId,
   pricingPlans,
@@ -42,15 +43,17 @@ export default function UpgradePage() {
         </div>
 
         {showYearlyToggle && (
-          <div className="mt-10 flex items-center justify-center">
+          <div className="flex items-center justify-center mt-10">
             <div
-              className="relative flex w-65 items-center justify-between rounded-full border bg-muted"
+              className="flex items-center justify-between bg-muted rounded-full relative w-[300px] border"
               role="radiogroup"
               aria-label="Billing frequency"
             >
               <button
                 onClick={() => setIsYearly(false)}
-                className="relative z-10 w-65 py-3 px-6 text-center text-sm font-medium"
+                className={`relative z-10 py-3 px-6 text-sm font-medium w-[120px] text-center ${
+                  !isYearly ? "text-white" : ""
+                }`}
                 role="radio"
                 aria-checked={!isYearly}
                 aria-label="Monthly billing"
@@ -59,23 +62,21 @@ export default function UpgradePage() {
               </button>
               <button
                 onClick={() => setIsYearly(true)}
-                className="relative z-10 w-65 py-3 px-6 text-center text-sm font-medium"
+                className={`relative z-10 py-3 px-6 text-sm font-medium w-[180px] text-center ${
+                  isYearly ? "text-white" : ""
+                }`}
                 role="radio"
                 aria-checked={isYearly}
                 aria-label="Yearly billing"
               >
-                Yearly
+                Yearly (20% off)
               </button>
               <motion.div
-                className="absolute z-0 rounded-full bg-primary text-primary-foreground"
+                className="absolute z-0 rounded-full bg-primary"
                 initial={false}
-                animate={{ x: isYearly ? 130 : 0 }}
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0 }
-                    : { type: "spring", stiffness: 300, damping: 30 }
-                }
-                style={{ width: 130, height: "100%" }}
+                animate={{ x: isYearly ? 120 : 0 }}
+                transition={shouldReduceMotion ? { duration: 0 } : { type: "spring", stiffness: 300, damping: 30 }}
+                style={{ width: isYearly ? 180 : 120, height: "100%" }}
               />
             </div>
           </div>
@@ -84,6 +85,9 @@ export default function UpgradePage() {
         <div className="@xl:grid-cols-2 @4xl:grid-cols-4 mt-12 grid gap-4">
           {pricingPlans.map((plan) => {
             const isBestValue = plan.planId === "growth";
+            const checkoutConfig = isPaidPlanId(plan.planId)
+              ? getCheckoutConfig(plan.planId, isYearly)
+              : null;
 
             return (
               <Card
@@ -142,6 +146,7 @@ export default function UpgradePage() {
                       <Button
                         className="w-full gap-2"
                         variant={isBestValue ? "default" : "outline"}
+                        disabled={!checkoutConfig}
                         onClick={async () => {
                           await handleCheckout(
                             plan.planId as PaidPlanId,
@@ -149,7 +154,11 @@ export default function UpgradePage() {
                           );
                         }}
                       >
-                        Subscribe
+                        {checkoutConfig
+                          ? "Subscribe"
+                          : isYearly
+                            ? "Yearly soon"
+                            : "Subscribe"}
                         <ArrowRight className="size-4" />
                       </Button>
                     ) : (

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -3,7 +3,13 @@
 import { Button } from "@pilot/ui/components/button";
 import { Check } from "lucide-react";
 import { Card, CardHeader, CardTitle } from "@pilot/ui/components/card";
-import { pricingPlans } from "@/lib/constants/pricing";
+import {
+  type PaidPlanId,
+  formatPlanPrice,
+  hasAnyYearlyPricing,
+  isPaidPlanId,
+  pricingPlans,
+} from "@/lib/constants/pricing";
 import { useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { handleCheckout } from "@/lib/polar/client";
@@ -11,10 +17,11 @@ import PlanBadge from "@/components/subscription-badge";
 export default function UpgradePage() {
   const [isYearly, setIsYearly] = useState(false);
   const shouldReduceMotion = useReducedMotion();
+  const showYearlyToggle = hasAnyYearlyPricing();
 
   return (
     <div className="relative my-auto">
-      <div className="mx-auto max-w-5xl px-6">
+      <div className="mx-auto max-w-360 px-6">
         <PlanBadge />
 
         <div className="mx-auto max-w-2xl text-center">
@@ -26,43 +33,49 @@ export default function UpgradePage() {
           </p>
         </div>
 
-        <div className="flex items-center justify-center mt-10">
-          <div
-            className="flex items-center justify-between bg-muted rounded-full relative w-[260px] border"
-            role="radiogroup"
-            aria-label="Billing frequency"
-          >
-            <button
-              onClick={() => setIsYearly(false)}
-              className="relative z-10 py-3 px-6 text-sm font-medium w-[130px] text-center"
-              role="radio"
-              aria-checked={!isYearly}
-              aria-label="Monthly billing"
+        {showYearlyToggle && (
+          <div className="mt-10 flex items-center justify-center">
+            <div
+              className="relative flex w-[260px] items-center justify-between rounded-full border bg-muted"
+              role="radiogroup"
+              aria-label="Billing frequency"
             >
-              Monthly
-            </button>
-            <button
-              onClick={() => setIsYearly(true)}
-              className="relative z-10 py-3 px-6 text-sm font-medium w-[130px] text-center"
-              role="radio"
-              aria-checked={isYearly}
-              aria-label="Yearly billing"
-            >
-              Yearly
-            </button>
-            <motion.div
-              className="absolute z-0 rounded-full bg-primary text-primary-foreground"
-              initial={false}
-              animate={{ x: isYearly ? 130 : 0 }}
-              transition={shouldReduceMotion ? { duration: 0 } : { type: "spring", stiffness: 300, damping: 30 }}
-              style={{ width: 130, height: "100%" }}
-            />
+              <button
+                onClick={() => setIsYearly(false)}
+                className="relative z-10 w-[130px] py-3 px-6 text-center text-sm font-medium"
+                role="radio"
+                aria-checked={!isYearly}
+                aria-label="Monthly billing"
+              >
+                Monthly
+              </button>
+              <button
+                onClick={() => setIsYearly(true)}
+                className="relative z-10 w-[130px] py-3 px-6 text-center text-sm font-medium"
+                role="radio"
+                aria-checked={isYearly}
+                aria-label="Yearly billing"
+              >
+                Yearly
+              </button>
+              <motion.div
+                className="absolute z-0 rounded-full bg-primary text-primary-foreground"
+                initial={false}
+                animate={{ x: isYearly ? 130 : 0 }}
+                transition={
+                  shouldReduceMotion
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 300, damping: 30 }
+                }
+                style={{ width: 130, height: "100%" }}
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="@container relative mt-10">
           <Card className="@4xl:max-w-full relative mx-auto max-w-sm p-0 border-l-0">
-            <div className="@4xl:grid-cols-2 grid">
+            <div className="@4xl:grid-cols-4 grid">
               {pricingPlans.map((plan) => (
                 <div
                   key={plan.title}
@@ -87,12 +100,12 @@ export default function UpgradePage() {
                         {plan.description}
                       </p>
                       <span className="mb-0.5 mt-4 block text-3xl font-semibold">
-                        {isYearly ? plan.yearlyPrice : plan.monthlyPrice}
+                        {formatPlanPrice(plan, isYearly)}
                         <span className="text-muted-foreground text-base font-normal ml-1">
                           / month
                         </span>
                       </span>
-                      {isYearly && (
+                      {showYearlyToggle && isYearly && (
                         <p className="text-xs text-muted-foreground mt-1">
                           Billed annually
                         </p>
@@ -102,17 +115,23 @@ export default function UpgradePage() {
                       className={`${plan.highlighted ? "@3xl:mx-0 -mx-1 " : ""
                         }border-y px-8 py-4`}
                     >
-                      <Button
-                        className="w-full"
-                        onClick={async () => {
-                          await handleCheckout(
-                            plan.title as "Starter" | "Premium",
-                            isYearly
-                          );
-                        }}
-                      >
-                        Subscribe
-                      </Button>
+                      {isPaidPlanId(plan.planId) ? (
+                        <Button
+                          className="w-full"
+                          onClick={async () => {
+                            await handleCheckout(
+                              plan.planId as PaidPlanId,
+                              isYearly
+                            );
+                          }}
+                        >
+                          Subscribe
+                        </Button>
+                      ) : (
+                        <Button className="w-full" variant="outline" disabled>
+                          Current free tier
+                        </Button>
+                      )}
                     </div>
 
                     <ul role="list" className="space-y-3 p-8">

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -58,9 +58,9 @@ export default function UpgradePage() {
             Pick a plan that fits your volume
           </h2>
           <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-balance text-base md:text-lg">
-            Start simple, then upgrade when you need more capacity. Limits are
-            enforced by tier, and you can update the quota values in code
-            whenever you want.
+            Every tier unlocks more capacity for contacts, automations, and
+            Sidekick usage. Start where you are now, then move up when your
+            volume demands it.
           </p>
         </div>
 
@@ -201,8 +201,8 @@ export default function UpgradePage() {
         </div>
 
         <p className="text-muted-foreground mt-8 text-center text-sm">
-          No free trials. Free access stays on the built-in free tier until you
-          subscribe.
+          No free trials. You stay on the built-in Free tier until you decide
+          to upgrade.
         </p>
       </div>
     </section>

--- a/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
+++ b/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx
@@ -12,19 +12,41 @@ import {
   type PaidPlanId,
   formatPlanPrice,
   getCheckoutConfig,
+  getPricingPlan,
   hasAnyYearlyPricing,
   isPaidPlanId,
   pricingPlans,
 } from "@/lib/constants/pricing";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { handleCheckout } from "@/lib/polar/client";
-import PlanBadge from "@/components/subscription-badge";
+import PlanBadge, { getSubscriptionData } from "@/components/subscription-badge";
 
 export default function UpgradePage() {
   const [isYearly, setIsYearly] = useState(false);
+  const [currentPlanTitle, setCurrentPlanTitle] = useState<string | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const showYearlyToggle = hasAnyYearlyPricing();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getSubscriptionData()
+      .then((planTitle) => {
+        if (!cancelled) {
+          setCurrentPlanTitle(planTitle);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCurrentPlanTitle(getPricingPlan("free").title);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <section className="bg-background @container">
@@ -88,6 +110,7 @@ export default function UpgradePage() {
             const checkoutConfig = isPaidPlanId(plan.planId)
               ? getCheckoutConfig(plan.planId, isYearly)
               : null;
+            const isCurrentPlan = currentPlanTitle === plan.title;
 
             return (
               <Card
@@ -142,7 +165,11 @@ export default function UpgradePage() {
                   </ul>
 
                   <div className="mt-auto pt-8">
-                    {isPaidPlanId(plan.planId) ? (
+                    {isCurrentPlan ? (
+                      <Button className="w-full" variant="outline" disabled>
+                        Current plan
+                      </Button>
+                    ) : isPaidPlanId(plan.planId) ? (
                       <Button
                         className="w-full gap-2"
                         variant={isBestValue ? "default" : "outline"}
@@ -162,8 +189,8 @@ export default function UpgradePage() {
                         <ArrowRight className="size-4" />
                       </Button>
                     ) : (
-                      <Button className="w-full" variant="outline" disabled>
-                        Current free tier
+                      <Button className="w-full gap-2" variant="outline" disabled>
+                        Start on free
                       </Button>
                     )}
                   </div>

--- a/apps/app/src/app/(dashboard)/(workspace)/automations/page.tsx
+++ b/apps/app/src/app/(dashboard)/(workspace)/automations/page.tsx
@@ -6,8 +6,15 @@ import AutomationsList from "@/components/automations/list";
 import AutomationsLogs from "@/components/automations/logs";
 import { Skeleton } from "@pilot/ui/components/skeleton";
 import { SidekickLayout } from "@/components/sidekick/layout";
+import { getUser } from "@/lib/auth-utils";
+import { getBillingStatus } from "@/lib/billing/enforce";
 
-export default function AutomationsPage() {
+export default async function AutomationsPage() {
+  const user = await getUser();
+  const billingStatus = user ? await getBillingStatus(user.id) : null;
+  const isFrozen = billingStatus?.flags.isStructurallyFrozen ?? false;
+  const canCreateAutomation = billingStatus?.flags.canCreateAutomation ?? false;
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -17,13 +24,26 @@ export default function AutomationsPage() {
             Build automated replies for common DM and comment questions.
           </p>
         </div>
-        <Button asChild className="mt-auto">
-          <Link href="/automations/new">
+        {canCreateAutomation ? (
+          <Button asChild className="mt-auto">
+            <Link href="/automations/new">
+              <Plus className="size-4" />
+              New Automation
+            </Link>
+          </Button>
+        ) : (
+          <Button className="mt-auto" disabled>
             <Plus className="size-4" />
             New Automation
-          </Link>
-        </Button>
+          </Button>
+        )}
       </div>
+
+      {isFrozen && (
+        <p className="text-sm text-muted-foreground">
+          Your workspace is frozen because it is above the current plan cap. Existing automations remain visible, but changes are disabled until usage is reduced or the plan is upgraded.
+        </p>
+      )}
 
       <SidekickLayout>
         <Suspense

--- a/apps/app/src/app/api/chat/route.ts
+++ b/apps/app/src/app/api/chat/route.ts
@@ -50,11 +50,37 @@ import {
   searchContacts,
 } from "@/actions/sidekick/ai-tools/contacts";
 import { loadChatSession } from "@/lib/chat-store";
+import { getUser } from "@/lib/auth-utils";
+import { BillingLimitError, assertBillingAllowed } from "@/lib/billing/enforce";
+import { recordSidekickChatPromptUsage } from "@/lib/billing/usage";
 
 export const maxDuration = 40;
 
 export async function POST(req: Request) {
   const { message, id } = await req.json();
+  const user = await getUser();
+
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await assertBillingAllowed(user.id, "sidekick:chat");
+  } catch (error) {
+    if (error instanceof BillingLimitError) {
+      return Response.json(
+        {
+          code: error.code,
+          error: error.message,
+        },
+        { status: 403 },
+      );
+    }
+
+    throw error;
+  }
+
+  await recordSidekickChatPromptUsage(user.id, id);
   console.log("Chat API called with:", {
     messageId: message.id,
     sessionId: id,

--- a/apps/app/src/app/api/chat/route.ts
+++ b/apps/app/src/app/api/chat/route.ts
@@ -52,10 +52,7 @@ import {
 import { loadChatSession } from "@/lib/chat-store";
 import { getUser } from "@/lib/auth-utils";
 import { BillingLimitError, assertBillingAllowed } from "@/lib/billing/enforce";
-import {
-  recordSidekickChatPromptUsage,
-  rollbackSidekickChatPromptUsage,
-} from "@/lib/billing/usage";
+import { recordSidekickChatPromptUsage } from "@/lib/billing/usage";
 
 export const maxDuration = 40;
 
@@ -389,62 +386,41 @@ export async function POST(req: Request) {
     }),
   };
 
-  let usageEventId: string | null = null;
-  let chatFinished = false;
+  const result = streamText({
+    model: geminiModel,
+    messages: convertToModelMessages(messages),
+    system,
+    tools,
+    stopWhen: stepCountIs(5),
+    experimental_transform: smoothStream({
+      delayInMs: 20,
+      chunking: "word",
+    }),
+    onError: async ({ error }) => {
+      console.error("Sidekick chat stream failed:", error);
+    },
+  });
 
-  try {
-    const result = streamText({
-      model: geminiModel,
-      messages: convertToModelMessages(messages),
-      system,
-      tools,
-      stopWhen: stepCountIs(5),
-      experimental_transform: smoothStream({
-        delayInMs: 20,
-        chunking: "word",
-      }),
-      onError: async ({ error }) => {
-        if (usageEventId && !chatFinished) {
-          try {
-            await rollbackSidekickChatPromptUsage(usageEventId);
-          } catch (rollbackError) {
-            console.error("Failed to rollback chat usage after stream error:", rollbackError);
-          }
-        }
-
-        console.error("Sidekick chat stream failed:", error);
-      },
-    });
-
-    usageEventId = await recordSidekickChatPromptUsage(user.id, id);
-
-    return result.toUIMessageStreamResponse({
-      originalMessages: messages,
-      onFinish: async ({ messages }) => {
-        chatFinished = true;
-
-        if (!id) {
-          return;
-        }
-
-        try {
-          const { saveChatSession } = await import("@/lib/chat-store");
-          await saveChatSession({ sessionId: id, messages });
-          console.log(`Saved ${messages.length} messages to session ${id}`);
-        } catch (error) {
-          console.error("Failed to save chat session:", error);
-        }
-      },
-    });
-  } catch (error) {
-    if (usageEventId) {
+  return result.toUIMessageStreamResponse({
+    originalMessages: messages,
+    onFinish: async ({ messages }) => {
       try {
-        await rollbackSidekickChatPromptUsage(usageEventId);
-      } catch (rollbackError) {
-        console.error("Failed to rollback chat usage after initialization error:", rollbackError);
+        await recordSidekickChatPromptUsage(user.id, id);
+      } catch (error) {
+        console.error("Failed to record chat usage:", error);
       }
-    }
 
-    throw error;
-  }
+      if (!id) {
+        return;
+      }
+
+      try {
+        const { saveChatSession } = await import("@/lib/chat-store");
+        await saveChatSession({ sessionId: id, messages });
+        console.log(`Saved ${messages.length} messages to session ${id}`);
+      } catch (error) {
+        console.error("Failed to save chat session:", error);
+      }
+    },
+  });
 }

--- a/apps/app/src/app/api/chat/route.ts
+++ b/apps/app/src/app/api/chat/route.ts
@@ -52,7 +52,10 @@ import {
 import { loadChatSession } from "@/lib/chat-store";
 import { getUser } from "@/lib/auth-utils";
 import { BillingLimitError, assertBillingAllowed } from "@/lib/billing/enforce";
-import { recordSidekickChatPromptUsage } from "@/lib/billing/usage";
+import {
+  recordSidekickChatPromptUsage,
+  rollbackSidekickChatPromptUsage,
+} from "@/lib/billing/usage";
 
 export const maxDuration = 40;
 
@@ -80,7 +83,6 @@ export async function POST(req: Request) {
     throw error;
   }
 
-  await recordSidekickChatPromptUsage(user.id, id);
   console.log("Chat API called with:", {
     messageId: message.id,
     sessionId: id,
@@ -387,32 +389,62 @@ export async function POST(req: Request) {
     }),
   };
 
-  const result = streamText({
-    model: geminiModel,
-    messages: convertToModelMessages(messages),
-    system,
-    tools,
-    stopWhen: stepCountIs(5),
-    experimental_transform: smoothStream({
-      delayInMs: 20,
-      chunking: "word",
-    }),
-  });
+  let usageEventId: string | null = null;
+  let chatFinished = false;
 
-  return result.toUIMessageStreamResponse({
-    originalMessages: messages,
-    onFinish: async ({ messages }) => {
-      if (!id) {
-        return;
-      }
+  try {
+    const result = streamText({
+      model: geminiModel,
+      messages: convertToModelMessages(messages),
+      system,
+      tools,
+      stopWhen: stepCountIs(5),
+      experimental_transform: smoothStream({
+        delayInMs: 20,
+        chunking: "word",
+      }),
+      onError: async ({ error }) => {
+        if (usageEventId && !chatFinished) {
+          try {
+            await rollbackSidekickChatPromptUsage(usageEventId);
+          } catch (rollbackError) {
+            console.error("Failed to rollback chat usage after stream error:", rollbackError);
+          }
+        }
 
+        console.error("Sidekick chat stream failed:", error);
+      },
+    });
+
+    usageEventId = await recordSidekickChatPromptUsage(user.id, id);
+
+    return result.toUIMessageStreamResponse({
+      originalMessages: messages,
+      onFinish: async ({ messages }) => {
+        chatFinished = true;
+
+        if (!id) {
+          return;
+        }
+
+        try {
+          const { saveChatSession } = await import("@/lib/chat-store");
+          await saveChatSession({ sessionId: id, messages });
+          console.log(`Saved ${messages.length} messages to session ${id}`);
+        } catch (error) {
+          console.error("Failed to save chat session:", error);
+        }
+      },
+    });
+  } catch (error) {
+    if (usageEventId) {
       try {
-        const { saveChatSession } = await import("@/lib/chat-store");
-        await saveChatSession({ sessionId: id, messages });
-        console.log(`Saved ${messages.length} messages to session ${id}`);
-      } catch (error) {
-        console.error("Failed to save chat session:", error);
+        await rollbackSidekickChatPromptUsage(usageEventId);
+      } catch (rollbackError) {
+        console.error("Failed to rollback chat usage after initialization error:", rollbackError);
       }
-    },
-  });
+    }
+
+    throw error;
+  }
 }

--- a/apps/app/src/app/api/webhooks/instagram/route.ts
+++ b/apps/app/src/app/api/webhooks/instagram/route.ts
@@ -4,6 +4,7 @@ import { verifyWebhookSignature } from "@pilot/instagram";
 import { processInstagramWebhook } from "@pilot/core/workflows/instagram-webhook";
 import { inngest } from "@/lib/inngest/client";
 import { env } from "@/env";
+import { getBillingStatus } from "@/lib/billing/enforce";
 
 type InstagramWebhookPayload = {
   object: string;
@@ -56,6 +57,7 @@ export async function POST(request: Request) {
       dbClient: db,
       inngestClient: inngest,
       payload,
+      resolveBillingStatus: getBillingStatus,
     });
 
     return NextResponse.json(result, { status: 200 });

--- a/apps/app/src/components/contacts/sync-contacts-button.tsx
+++ b/apps/app/src/components/contacts/sync-contacts-button.tsx
@@ -8,18 +8,23 @@ import {
   getContactsLastUpdatedAt,
   hasContactsUpdatedSince,
 } from "@/actions/contacts";
-import { getCurrentBillingStatusAction } from "@/actions/billing";
 import { getSyncSubscribeToken } from "@/actions/realtime";
 import { useInngestSubscription } from "@inngest/realtime/hooks";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LoaderCircle, RefreshCw } from "lucide-react";
+
+const SYNC_STATUS_POLL_INTERVAL_MS = 1_200;
+const MAX_SYNC_STATUS_WAIT_MS = 10_000;
+const MANUAL_SYNC_COOLDOWN_MS = 2 * 60 * 60 * 1000;
+const MANUAL_SYNC_STORAGE_KEY = "pilot:last-manual-contact-sync-at";
 
 async function performSync(
   fullSync: boolean,
   realtimeStatusRef: React.RefObject<string | undefined>,
   setIsLoading: (v: boolean) => void,
-  setRealtimeStatus: (v: string | undefined) => void
+  setRealtimeStatus: (v: string | undefined) => void,
+  setNextAllowedAt: (v: string | null) => void,
 ) {
   try {
     setIsLoading(true);
@@ -30,9 +35,18 @@ async function performSync(
     const result = await syncInstagramContacts(fullSync);
 
     if (result.success) {
+      const nextAllowedAt = new Date(
+        Date.now() + MANUAL_SYNC_COOLDOWN_MS,
+      ).toISOString();
+      setNextAllowedAt(nextAllowedAt);
+      window.localStorage.setItem(
+        MANUAL_SYNC_STORAGE_KEY,
+        new Date().toISOString(),
+      );
+
       const start = Date.now();
       let updated = false;
-      while (Date.now() - start < Infinity) {
+      while (Date.now() - start < MAX_SYNC_STATUS_WAIT_MS) {
         if (before) {
           const { updated: hasUpdated } = await hasContactsUpdatedSince(before);
           if (hasUpdated) {
@@ -40,11 +54,11 @@ async function performSync(
             break;
           }
         } else {
-          await new Promise((r) => setTimeout(r, 1200));
+          await new Promise((r) => setTimeout(r, SYNC_STATUS_POLL_INTERVAL_MS));
           updated = true;
           break;
         }
-        await new Promise((r) => setTimeout(r, 1200));
+        await new Promise((r) => setTimeout(r, SYNC_STATUS_POLL_INTERVAL_MS));
       }
       const statusMsg = realtimeStatusRef.current;
       toast.success(
@@ -60,8 +74,8 @@ async function performSync(
       const errorMessage = result.error?.includes("token expired")
         ? "Instagram token expired. Please reconnect your Instagram account in Settings."
         : result.error || "Failed to sync contacts. Please try again later.";
-
       toast.error(errorMessage);
+
       console.error("Sync failed:", result.error);
     }
   } catch (error) {
@@ -75,56 +89,105 @@ async function performSync(
 export default function SyncContactsButton() {
   const [isLoading, setIsLoading] = useState(false);
   const [fullSync, setFullSync] = useState(false);
-  const [billingMessage, setBillingMessage] = useState<string | null>(null);
+  const [rateLimitMessage, setRateLimitMessage] = useState<string | null>(null);
   const [syncDisabled, setSyncDisabled] = useState(false);
+  const [nextAllowedAt, setNextAllowedAt] = useState<string | null>(null);
   const [realtimeStatus, setRealtimeStatus] = useState<string | undefined>(
     undefined
   );
   const realtimeStatusRef = useRef<string | undefined>(undefined);
+  const hasShownCooldownToastRef = useRef(false);
 
   useEffect(() => {
     realtimeStatusRef.current = realtimeStatus;
   }, [realtimeStatus]);
 
   useEffect(() => {
-    let cancelled = false;
+    const lastManualSyncAt = window.localStorage.getItem(MANUAL_SYNC_STORAGE_KEY);
 
-    getCurrentBillingStatusAction()
-      .then((billingStatus) => {
-        if (cancelled || !billingStatus) {
-          return;
-        }
+    if (!lastManualSyncAt) {
+      hasShownCooldownToastRef.current = false;
+      return;
+    }
 
-        if (billingStatus.flags.isStructurallyFrozen) {
-          setSyncDisabled(true);
-          setBillingMessage(
-            "Sync is disabled while your workspace is frozen above the current plan cap."
-          );
-          return;
-        }
+    const nextAllowedAt = new Date(
+      new Date(lastManualSyncAt).getTime() + MANUAL_SYNC_COOLDOWN_MS,
+    );
 
-        setSyncDisabled(false);
+    if (Number.isNaN(nextAllowedAt.getTime()) || nextAllowedAt.getTime() <= Date.now()) {
+      window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
+      hasShownCooldownToastRef.current = false;
+      return;
+    }
 
-        if (!billingStatus.flags.canCreateContact) {
-          setBillingMessage(
-            "New contact capacity is exhausted for this month. Existing contacts can still refresh."
-          );
-          return;
-        }
+    const retryAfterMs = nextAllowedAt.getTime() - Date.now();
+    setNextAllowedAt(nextAllowedAt.toISOString());
 
-        setBillingMessage(null);
-      })
-      .catch((error) => {
-        console.error("Failed to load billing status:", error);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    if (!hasShownCooldownToastRef.current) {
+      hasShownCooldownToastRef.current = true;
+      toast.info(
+        `Manual sync is cooling down. Available again in ${formatRemainingDuration(
+          retryAfterMs,
+        )}.`,
+      );
+    }
   }, []);
 
-  const handleSync = () =>
-    performSync(fullSync, realtimeStatusRef, setIsLoading, setRealtimeStatus);
+  useEffect(() => {
+    if (!nextAllowedAt) {
+      setSyncDisabled(false);
+      setRateLimitMessage(null);
+      return;
+    }
+
+    const updateCooldownState = () => {
+      const remainingMs = new Date(nextAllowedAt).getTime() - Date.now();
+
+      if (remainingMs <= 0) {
+        setSyncDisabled(false);
+        setRateLimitMessage(null);
+        setNextAllowedAt(null);
+        hasShownCooldownToastRef.current = false;
+        window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
+        return;
+      }
+
+      setSyncDisabled(true);
+      setRateLimitMessage(
+        `Manual sync is available again in ${formatRemainingDuration(remainingMs)}.`,
+      );
+    };
+
+    updateCooldownState();
+    const interval = window.setInterval(updateCooldownState, 60_000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [nextAllowedAt]);
+
+  const handleSync = () => {
+    if (nextAllowedAt) {
+      const remainingMs = new Date(nextAllowedAt).getTime() - Date.now();
+
+      if (remainingMs > 0) {
+        toast.error(
+          `Manual sync is rate-limited. Try again in ${formatRemainingDuration(
+            remainingMs,
+          )}.`,
+        );
+        return;
+      }
+    }
+
+    return performSync(
+      fullSync,
+      realtimeStatusRef,
+      setIsLoading,
+      setRealtimeStatus,
+      setNextAllowedAt,
+    );
+  };
 
   return (
     <div className="flex items-center gap-3">
@@ -133,8 +196,8 @@ export default function SyncContactsButton() {
           onCompleted={() => setRealtimeStatus("Sync complete.")}
         />
       )}
-      {billingMessage && (
-        <p className="text-xs text-muted-foreground">{billingMessage}</p>
+      {rateLimitMessage && (
+        <p className="text-xs text-muted-foreground">{rateLimitMessage}</p>
       )}
       <div className="flex items-center gap-2">
         <Checkbox
@@ -164,20 +227,37 @@ export default function SyncContactsButton() {
   );
 }
 
+function formatRemainingDuration(remainingMs: number) {
+  const totalMinutes = Math.max(1, Math.ceil(remainingMs / 60_000));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+
+  return `${minutes}m`;
+}
+
 function RealtimeSyncWatcher({ onCompleted }: { onCompleted: () => void }) {
   const { latestData } = useInngestSubscription({
     refreshToken: getSyncSubscribeToken,
   });
+  const onCompletedEvent = useEffectEvent(onCompleted);
 
   useEffect(() => {
     if (latestData?.data?.status === "completed") {
       // Small delay or schedule for next turn to ensure it's not synchronous in effect body
       const timer = setTimeout(() => {
-        onCompleted();
+        onCompletedEvent();
       }, 0);
       return () => clearTimeout(timer);
     }
-  }, [latestData, onCompleted]);
+  }, [latestData, onCompletedEvent]);
 
   return null;
 }

--- a/apps/app/src/components/contacts/sync-contacts-button.tsx
+++ b/apps/app/src/components/contacts/sync-contacts-button.tsx
@@ -19,6 +19,31 @@ const MAX_SYNC_STATUS_WAIT_MS = 10_000;
 const MANUAL_SYNC_COOLDOWN_MS = 2 * 60 * 60 * 1000;
 const MANUAL_SYNC_STORAGE_KEY = "pilot:last-manual-contact-sync-at";
 
+function getStoredNextAllowedAt() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const lastManualSyncAt = window.localStorage.getItem(MANUAL_SYNC_STORAGE_KEY);
+  if (!lastManualSyncAt) {
+    return null;
+  }
+
+  const nextAllowedAt = new Date(
+    new Date(lastManualSyncAt).getTime() + MANUAL_SYNC_COOLDOWN_MS,
+  );
+
+  if (
+    Number.isNaN(nextAllowedAt.getTime()) ||
+    nextAllowedAt.getTime() <= Date.now()
+  ) {
+    window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
+    return null;
+  }
+
+  return nextAllowedAt.toISOString();
+}
+
 async function performSync(
   fullSync: boolean,
   realtimeStatusRef: React.RefObject<string | undefined>,
@@ -89,95 +114,90 @@ async function performSync(
 export default function SyncContactsButton() {
   const [isLoading, setIsLoading] = useState(false);
   const [fullSync, setFullSync] = useState(false);
-  const [rateLimitMessage, setRateLimitMessage] = useState<string | null>(null);
-  const [syncDisabled, setSyncDisabled] = useState(false);
-  const [nextAllowedAt, setNextAllowedAt] = useState<string | null>(null);
+  const [nextAllowedAt, setNextAllowedAt] = useState<string | null>(
+    getStoredNextAllowedAt,
+  );
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [realtimeStatus, setRealtimeStatus] = useState<string | undefined>(
-    undefined
+    undefined,
   );
   const realtimeStatusRef = useRef<string | undefined>(undefined);
   const hasShownCooldownToastRef = useRef(false);
+  const remainingMs = nextAllowedAt
+    ? new Date(nextAllowedAt).getTime() - nowMs
+    : 0;
+  const syncDisabled = remainingMs > 0;
+  const rateLimitMessage = syncDisabled
+    ? `Manual sync is available again in ${formatRemainingDuration(remainingMs)}.`
+    : null;
 
   useEffect(() => {
     realtimeStatusRef.current = realtimeStatus;
   }, [realtimeStatus]);
 
   useEffect(() => {
-    const lastManualSyncAt = window.localStorage.getItem(MANUAL_SYNC_STORAGE_KEY);
-
-    if (!lastManualSyncAt) {
-      hasShownCooldownToastRef.current = false;
-      return;
-    }
-
-    const nextAllowedAt = new Date(
-      new Date(lastManualSyncAt).getTime() + MANUAL_SYNC_COOLDOWN_MS,
-    );
-
-    if (Number.isNaN(nextAllowedAt.getTime()) || nextAllowedAt.getTime() <= Date.now()) {
-      window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
-      hasShownCooldownToastRef.current = false;
-      return;
-    }
-
-    const retryAfterMs = nextAllowedAt.getTime() - Date.now();
-    setNextAllowedAt(nextAllowedAt.toISOString());
-
-    if (!hasShownCooldownToastRef.current) {
+    if (syncDisabled && !hasShownCooldownToastRef.current) {
       hasShownCooldownToastRef.current = true;
       toast.info(
         `Manual sync is cooling down. Available again in ${formatRemainingDuration(
-          retryAfterMs,
+          remainingMs,
         )}.`,
       );
     }
-  }, []);
+
+    if (!syncDisabled) {
+      hasShownCooldownToastRef.current = false;
+    }
+  }, [remainingMs, syncDisabled]);
 
   useEffect(() => {
-    if (!nextAllowedAt) {
-      setSyncDisabled(false);
-      setRateLimitMessage(null);
+    if (!syncDisabled) {
       return;
     }
 
-    const updateCooldownState = () => {
-      const remainingMs = new Date(nextAllowedAt).getTime() - Date.now();
-
-      if (remainingMs <= 0) {
-        setSyncDisabled(false);
-        setRateLimitMessage(null);
-        setNextAllowedAt(null);
-        hasShownCooldownToastRef.current = false;
-        window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
-        return;
-      }
-
-      setSyncDisabled(true);
-      setRateLimitMessage(
-        `Manual sync is available again in ${formatRemainingDuration(remainingMs)}.`,
-      );
-    };
-
-    updateCooldownState();
-    const interval = window.setInterval(updateCooldownState, 60_000);
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 60_000);
 
     return () => {
       window.clearInterval(interval);
     };
-  }, [nextAllowedAt]);
+  }, [syncDisabled]);
 
-  const handleSync = () => {
-    if (nextAllowedAt) {
-      const remainingMs = new Date(nextAllowedAt).getTime() - Date.now();
+  useEffect(() => {
+    if (!nextAllowedAt || syncDisabled) {
+      return;
+    }
 
-      if (remainingMs > 0) {
-        toast.error(
-          `Manual sync is rate-limited. Try again in ${formatRemainingDuration(
-            remainingMs,
-          )}.`,
-        );
+    window.localStorage.removeItem(MANUAL_SYNC_STORAGE_KEY);
+  }, [nextAllowedAt, syncDisabled]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== MANUAL_SYNC_STORAGE_KEY) {
         return;
       }
+
+      hasShownCooldownToastRef.current = false;
+      setNowMs(Date.now());
+      setNextAllowedAt(getStoredNextAllowedAt());
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const handleSync = () => {
+    if (syncDisabled) {
+      toast.error(
+        `Manual sync is rate-limited. Try again in ${formatRemainingDuration(
+          remainingMs,
+        )}.`,
+      );
+      return;
     }
 
     return performSync(
@@ -185,7 +205,10 @@ export default function SyncContactsButton() {
       realtimeStatusRef,
       setIsLoading,
       setRealtimeStatus,
-      setNextAllowedAt,
+      (value) => {
+        setNowMs(Date.now());
+        setNextAllowedAt(value);
+      },
     );
   };
 

--- a/apps/app/src/components/contacts/sync-contacts-button.tsx
+++ b/apps/app/src/components/contacts/sync-contacts-button.tsx
@@ -8,6 +8,7 @@ import {
   getContactsLastUpdatedAt,
   hasContactsUpdatedSince,
 } from "@/actions/contacts";
+import { getCurrentBillingStatusAction } from "@/actions/billing";
 import { getSyncSubscribeToken } from "@/actions/realtime";
 import { useInngestSubscription } from "@inngest/realtime/hooks";
 import { useEffect, useRef, useState } from "react";
@@ -58,7 +59,7 @@ async function performSync(
     } else {
       const errorMessage = result.error?.includes("token expired")
         ? "Instagram token expired. Please reconnect your Instagram account in Settings."
-        : "Failed to sync contacts. Please try again later.";
+        : result.error || "Failed to sync contacts. Please try again later.";
 
       toast.error(errorMessage);
       console.error("Sync failed:", result.error);
@@ -74,6 +75,8 @@ async function performSync(
 export default function SyncContactsButton() {
   const [isLoading, setIsLoading] = useState(false);
   const [fullSync, setFullSync] = useState(false);
+  const [billingMessage, setBillingMessage] = useState<string | null>(null);
+  const [syncDisabled, setSyncDisabled] = useState(false);
   const [realtimeStatus, setRealtimeStatus] = useState<string | undefined>(
     undefined
   );
@@ -82,6 +85,43 @@ export default function SyncContactsButton() {
   useEffect(() => {
     realtimeStatusRef.current = realtimeStatus;
   }, [realtimeStatus]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentBillingStatusAction()
+      .then((billingStatus) => {
+        if (cancelled || !billingStatus) {
+          return;
+        }
+
+        if (billingStatus.flags.isStructurallyFrozen) {
+          setSyncDisabled(true);
+          setBillingMessage(
+            "Sync is disabled while your workspace is frozen above the current plan cap."
+          );
+          return;
+        }
+
+        setSyncDisabled(false);
+
+        if (!billingStatus.flags.canCreateContact) {
+          setBillingMessage(
+            "New contact capacity is exhausted for this month. Existing contacts can still refresh."
+          );
+          return;
+        }
+
+        setBillingMessage(null);
+      })
+      .catch((error) => {
+        console.error("Failed to load billing status:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleSync = () =>
     performSync(fullSync, realtimeStatusRef, setIsLoading, setRealtimeStatus);
@@ -93,19 +133,26 @@ export default function SyncContactsButton() {
           onCompleted={() => setRealtimeStatus("Sync complete.")}
         />
       )}
+      {billingMessage && (
+        <p className="text-xs text-muted-foreground">{billingMessage}</p>
+      )}
       <div className="flex items-center gap-2">
         <Checkbox
           id="full-sync"
           checked={fullSync}
           onCheckedChange={(checked) => setFullSync(Boolean(checked))}
           className="border-border data-[state=checked]:bg-primary"
-          disabled={isLoading}
+          disabled={isLoading || syncDisabled}
         />
         <Label htmlFor="full-sync" className="text-sm">
           Full sync
         </Label>
       </div>
-      <Button onClick={handleSync} disabled={isLoading} className="gap-2">
+      <Button
+        onClick={handleSync}
+        disabled={isLoading || syncDisabled}
+        className="gap-2"
+      >
         {isLoading ? (
           <LoaderCircle className="size-4 animate-spin" />
         ) : (

--- a/apps/app/src/components/sidekick/chatbot.tsx
+++ b/apps/app/src/components/sidekick/chatbot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, Fragment, useEffect, useRef } from "react";
+import { useState, Fragment, useEffect, useEffectEvent, useRef } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, UIMessage } from "ai";
 import { Bot } from "lucide-react";
@@ -388,43 +388,55 @@ export function SidekickChatbot({
     }
   }, [activeSessionId, sendMessage]);
 
+  const refreshBillingStatus = useEffectEvent(async () => {
+    try {
+      const billingStatus = await getCurrentBillingStatusAction();
+
+      if (!billingStatus) {
+        return true;
+      }
+
+      if (billingStatus.flags.isStructurallyFrozen) {
+        setBillingBlockedMessage(
+          "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but Sidekick chat is disabled until you upgrade or reduce usage.",
+        );
+        return false;
+      }
+
+      if (!billingStatus.flags.canUseSidekickChat) {
+        setBillingBlockedMessage(
+          "You have reached the monthly Sidekick chat limit for your current plan.",
+        );
+        return false;
+      }
+
+      setBillingBlockedMessage(null);
+      return true;
+    } catch (error) {
+      console.error("Failed to load billing status:", error);
+      return true;
+    }
+  });
+
   useEffect(() => {
     let cancelled = false;
 
-    getCurrentBillingStatusAction()
-      .then((billingStatus) => {
-        if (cancelled || !billingStatus) {
-          return;
-        }
-
-        if (billingStatus.flags.isStructurallyFrozen) {
-          setBillingBlockedMessage(
-            "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but Sidekick chat is disabled until you upgrade or reduce usage.",
-          );
-          return;
-        }
-
-        if (!billingStatus.flags.canUseSidekickChat) {
-          setBillingBlockedMessage(
-            "You have reached the monthly Sidekick chat limit for your current plan.",
-          );
-          return;
-        }
-
-        setBillingBlockedMessage(null);
-      })
-      .catch((error) => {
-        console.error("Failed to load billing status:", error);
-      });
+    void refreshBillingStatus().then((isAllowed) => {
+      if (cancelled || isAllowed) {
+        return;
+      }
+    });
 
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshBillingStatus]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (billingBlockedMessage) {
+
+    const canSubmit = await refreshBillingStatus();
+    if (!canSubmit) {
       return;
     }
 

--- a/apps/app/src/components/sidekick/chatbot.tsx
+++ b/apps/app/src/components/sidekick/chatbot.tsx
@@ -27,6 +27,7 @@ import {
   ToolOutput,
 } from "@/components/ai-elements/tool";
 import { AI_TOOLS, ToolInfo } from "@/lib/constants/ai-tools";
+import { getCurrentBillingStatusAction } from "@/actions/billing";
 
 interface UserProfile {
   name: string;
@@ -128,7 +129,7 @@ interface ToolOutput {
 function renderToolOutput(
   toolName: string,
   output: ToolOutput | undefined,
-  toolInfo?: ToolInfo
+  toolInfo?: ToolInfo,
 ): string {
   if (!output || !output.success) {
     return `❌ **Error**: ${output?.error || "Unknown error occurred"}`;
@@ -158,7 +159,7 @@ ${offers
   .map(
     (offer, index: number) =>
       `${index + 1}. **${offer.name}**${offer.value ? ` - $${offer.value}` : ""}
-   ${offer.content}`
+   ${offer.content}`,
   )
   .join("\n\n")}`;
 
@@ -197,7 +198,7 @@ ${faqs
   .map(
     (faq, index: number) =>
       `${index + 1}. **Q:** ${faq.question}
-   **A:** ${faq.answer || "No answer provided"}`
+   **A:** ${faq.answer || "No answer provided"}`,
   )
   .join("\n\n")}`;
 
@@ -224,7 +225,7 @@ ${logs
      log.text
        ? `${log.text.substring(0, 100)}${log.text.length > 100 ? "..." : ""}`
        : "N/A"
-   }   **Date:** ${new Date(log.createdAt).toLocaleString()}`
+   }   **Date:** ${new Date(log.createdAt).toLocaleString()}`,
   )
   .join("\n\n")}`;
 
@@ -252,8 +253,8 @@ ${contacts
     (contact, index: number) =>
       `${index + 1}. **${contact.username || "Unknown"}** (${contact.stage})
    **Sentiment:** ${contact.sentiment}${
-        contact.leadScore ? ` | **Score:** ${contact.leadScore}` : ""
-      }
+     contact.leadScore ? ` | **Score:** ${contact.leadScore}` : ""
+   }
    **Last Message:** ${
      contact.lastMessage
        ? `${contact.lastMessage.substring(0, 100)}${
@@ -261,7 +262,7 @@ ${contacts
          }`
        : "None"
    }
-   **Created:** ${new Date(contact.createdAt).toLocaleDateString()}`
+   **Created:** ${new Date(contact.createdAt).toLocaleDateString()}`,
   )
   .join("\n\n")}`;
 
@@ -308,15 +309,15 @@ ${searchResults
     (contact, index: number) =>
       `${index + 1}. **${contact.username || "Unknown"}** (${contact.stage})
    **Sentiment:** ${contact.sentiment}${
-        contact.leadScore ? ` | **Score:** ${contact.leadScore}` : ""
-      }
+     contact.leadScore ? ` | **Score:** ${contact.leadScore}` : ""
+   }
    **Notes:** ${
      contact.notes
        ? `${contact.notes.substring(0, 100)}${
            contact.notes.length > 100 ? "..." : ""
          }`
        : "None"
-   }`
+   }`,
   )
   .join("\n\n")}`;
 
@@ -358,7 +359,12 @@ export function SidekickChatbot({
   onSessionCreated,
 }: SidekickChatbotProps) {
   const [input, setInput] = useState("");
-  const [createdSessionId, setCreatedSessionId] = useState<string | undefined>();
+  const [createdSessionId, setCreatedSessionId] = useState<
+    string | undefined
+  >();
+  const [billingBlockedMessage, setBillingBlockedMessage] = useState<
+    string | null
+  >(null);
   const pendingMessageRef = useRef<string | null>(null);
 
   const activeSessionId = sessionId ?? createdSessionId;
@@ -382,8 +388,46 @@ export function SidekickChatbot({
     }
   }, [activeSessionId, sendMessage]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentBillingStatusAction()
+      .then((billingStatus) => {
+        if (cancelled || !billingStatus) {
+          return;
+        }
+
+        if (billingStatus.flags.isStructurallyFrozen) {
+          setBillingBlockedMessage(
+            "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but Sidekick chat is disabled until you upgrade or reduce usage.",
+          );
+          return;
+        }
+
+        if (!billingStatus.flags.canUseSidekickChat) {
+          setBillingBlockedMessage(
+            "You have reached the monthly Sidekick chat limit for your current plan.",
+          );
+          return;
+        }
+
+        setBillingBlockedMessage(null);
+      })
+      .catch((error) => {
+        console.error("Failed to load billing status:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (billingBlockedMessage) {
+      return;
+    }
+
     if (input.trim()) {
       if (!activeSessionId) {
         const messageText = input;
@@ -419,7 +463,8 @@ export function SidekickChatbot({
                   Hey! I&apos;m your Sidekick.
                 </h3>
                 <p className="text-base max-w-md mx-auto text-balance mt-2">
-                  Ask about leads, automations, or settings. I can also help you draft next replies.
+                  Ask about leads, automations, or settings. I can also help you
+                  draft next replies.
                 </p>
               </div>
             </div>
@@ -444,7 +489,7 @@ export function SidekickChatbot({
                     if (part.type.startsWith("tool-")) {
                       const toolName = part.type.replace("tool-", "");
                       const toolInfo = AI_TOOLS.find(
-                        (tool) => tool.name === toolName
+                        (tool) => tool.name === toolName,
                       );
 
                       if (
@@ -471,7 +516,7 @@ export function SidekickChatbot({
                                         {renderToolOutput(
                                           toolName,
                                           part.output as ToolOutput,
-                                          toolInfo
+                                          toolInfo,
                                         )}
                                       </Response>
                                     ) : undefined
@@ -496,14 +541,20 @@ export function SidekickChatbot({
       </Conversation>
 
       <div className="border-t p-4">
+        {billingBlockedMessage && (
+          <p className="mb-3 text-sm text-muted-foreground">
+            {billingBlockedMessage}
+          </p>
+        )}
         <PromptInput onSubmit={handleSubmit}>
           <PromptInputTextarea
             onChange={(e) => setInput(e.target.value)}
             value={input}
+            disabled={Boolean(billingBlockedMessage)}
           />
           <PromptInputSubmit
             className="m-2 float-right"
-            disabled={!input}
+            disabled={!input || Boolean(billingBlockedMessage)}
             status={status}
           />
         </PromptInput>

--- a/apps/app/src/components/subscription-badge.tsx
+++ b/apps/app/src/components/subscription-badge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Skeleton } from "@pilot/ui/components/skeleton";
 import { Suspense, useState, useEffect } from "react";
 import { authClient } from "@/lib/auth-client";

--- a/apps/app/src/components/subscription-badge.tsx
+++ b/apps/app/src/components/subscription-badge.tsx
@@ -1,26 +1,10 @@
 import { Skeleton } from "@pilot/ui/components/skeleton";
 import { Suspense, useState, useEffect } from "react";
 import { authClient } from "@/lib/auth-client";
-
-const PRODUCT_IDS = {
-  Starter: [
-    "89404de5-5d64-45fd-872d-d5969cf059ce",
-    "640c8f73-66dd-43ab-83a3-ecf6e01bf01e",
-  ],
-  Premium: [
-    "b1b9e32b-9417-4e99-8142-11ee6ce45bdc",
-    "a9ad37ae-90cd-4c2e-8fd6-88a430f8afb6",
-  ],
-};
-
-function getSubscriptionNameByProductId(productId: string): string {
-  for (const [plan, ids] of Object.entries(PRODUCT_IDS)) {
-    if (ids.includes(productId)) {
-      return plan;
-    }
-  }
-  return productId;
-}
+import {
+  getPricingPlan,
+  resolvePlanIdFromProductId,
+} from "@/lib/constants/pricing";
 
 export async function getSubscriptionData() {
   try {
@@ -32,13 +16,13 @@ export async function getSubscriptionData() {
       customerState.activeSubscriptions.length > 0
     ) {
       const subscription = customerState.activeSubscriptions[0];
-      const planName = getSubscriptionNameByProductId(subscription.productId);
-      return planName;
+      const planId = resolvePlanIdFromProductId(subscription.productId);
+      return getPricingPlan(planId).title;
     }
 
-    return "Free";
+    return getPricingPlan("free").title;
   } catch {
-    return "Free";
+    return getPricingPlan("free").title;
   }
 }
 

--- a/apps/app/src/components/user-profile.tsx
+++ b/apps/app/src/components/user-profile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@pilot/ui/components/button";
 import {
   DropdownMenu,
@@ -13,14 +13,99 @@ import { Avatar, AvatarFallback, AvatarImage } from "@pilot/ui/components/avatar
 import { useSession, signOut } from "@/lib/auth-client";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { LogOutIcon } from "lucide-react";
+import { AlertCircleIcon, LogOutIcon } from "lucide-react";
 import { cn } from "@pilot/ui/lib/utils";
 import { useSidebar } from "@pilot/ui/components/sidebar";
+import { getUserProfile } from "@/actions/sidekick/ai-tools/user-profile";
+
+type UserQuotaSummary = {
+  exceeded: boolean;
+  planName: string;
+  usage: {
+    contactsTotal: number;
+    newContactsThisMonth: number;
+    automationsTotal: number;
+    sidekickSendsThisMonth: number;
+    sidekickChatPromptsThisMonth: number;
+  };
+  limits: {
+    maxContactsTotal: number | null;
+    maxNewContactsPerMonth: number | null;
+    maxAutomations: number | null;
+    maxSidekickSendsPerMonth: number | null;
+    maxSidekickChatPromptsPerMonth: number | null;
+  };
+};
+
+function useUserQuotaSummary() {
+  const [quota, setQuota] = useState<UserQuotaSummary | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getUserProfile()
+      .then((result) => {
+        if (!cancelled && result.success) {
+          setQuota((result.profile as { quota?: UserQuotaSummary }).quota ?? null);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to load user quota summary:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return quota;
+}
+
+function formatQuotaLine(used: number, limit: number | null, label: string) {
+  return `${label}: ${used}${limit === null ? "" : ` / ${limit}`}`;
+}
+
+function AvatarAlertBadge() {
+  return (
+    <span className="absolute -right-0.5 -top-0.5 rounded-full bg-destructive p-0.5 text-destructive-foreground shadow-sm">
+      <AlertCircleIcon className="size-3.5" />
+    </span>
+  );
+}
+
+function ProfileAvatar({
+  image,
+  name,
+  sizeClassName,
+  showAlert,
+}: {
+  image?: string | null;
+  name?: string | null;
+  sizeClassName?: string;
+  showAlert: boolean;
+}) {
+  return (
+    <div className={cn("relative", sizeClassName)}>
+      <Avatar className={cn("size-full", sizeClassName)}>
+        <AvatarImage
+          src={image ?? ""}
+          alt={name ?? ""}
+          className="rounded-full"
+        />
+        <AvatarFallback className="rounded-full">
+          {name?.charAt(0)}
+        </AvatarFallback>
+      </Avatar>
+      {showAlert ? <AvatarAlertBadge /> : null}
+    </div>
+  );
+}
 
 export function UserProfile({ className }: { className?: string }) {
   const [signingOut, setSigningOut] = useState(false);
   const { data: session, isPending } = useSession();
   const router = useRouter();
+  const quota = useUserQuotaSummary();
 
   if (isPending) {
     return (
@@ -46,19 +131,14 @@ export function UserProfile({ className }: { className?: string }) {
           )}
           asChild
         >
-          <Avatar>
-            <AvatarImage
-              src={session.user.image ?? ""}
-              alt={session.user.name ?? ""}
-              className="rounded-full"
-            />
-            <AvatarFallback className="rounded-full">
-              {session.user.name?.charAt(0)}
-            </AvatarFallback>
-          </Avatar>
+          <ProfileAvatar
+            image={session.user.image}
+            name={session.user.name}
+            showAlert={Boolean(quota?.exceeded)}
+          />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-[300px]">
+      <DropdownMenuContent className="w-75">
         <div className="p-4 flex flex-col gap-4">
           <div className="flex items-center justify-between gap-4">
             <div className="flex flex-col">
@@ -67,17 +147,23 @@ export function UserProfile({ className }: { className?: string }) {
                 {session.user.email}
               </p>
             </div>
-            <Avatar className="size-8">
-              <AvatarImage
-                src={session.user.image ?? ""}
-                alt={session.user.name ?? ""}
-                className="rounded-full"
-              />
-              <AvatarFallback className="rounded-full">
-                {session.user.name?.charAt(0)}
-              </AvatarFallback>
-            </Avatar>
+            <ProfileAvatar
+              image={session.user.image}
+              name={session.user.name}
+              sizeClassName="size-8"
+              showAlert={Boolean(quota?.exceeded)}
+            />
           </div>
+          {quota ? (
+            <div className="rounded-lg border p-3 text-xs text-muted-foreground">
+              <p className="font-medium text-foreground">{quota.planName} usage</p>
+              <p>{formatQuotaLine(quota.usage.contactsTotal, quota.limits.maxContactsTotal, "Contacts")}</p>
+              <p>{formatQuotaLine(quota.usage.newContactsThisMonth, quota.limits.maxNewContactsPerMonth, "New contacts this month")}</p>
+              <p>{formatQuotaLine(quota.usage.automationsTotal, quota.limits.maxAutomations, "Automations")}</p>
+              <p>{formatQuotaLine(quota.usage.sidekickSendsThisMonth, quota.limits.maxSidekickSendsPerMonth, "AI sends this month")}</p>
+              <p>{formatQuotaLine(quota.usage.sidekickChatPromptsThisMonth, quota.limits.maxSidekickChatPromptsPerMonth, "Sidekick chats this month")}</p>
+            </div>
+          ) : null}
         </div>
         {/* <DropdownMenuSeparator />
         <DropdownMenuItem className="cursor-pointer" asChild>
@@ -143,6 +229,7 @@ export function UserProfileDesktop({ className }: { className?: string }) {
   const [signingOut, setSigningOut] = useState(false);
   const { data: session, isPending } = useSession();
   const router = useRouter();
+  const quota = useUserQuotaSummary();
 
   if (isPending) {
     return (
@@ -167,16 +254,12 @@ export function UserProfileDesktop({ className }: { className?: string }) {
               signingOut && "animate-pulse"
             )}
           >
-            <Avatar className="size-10 shrink-0">
-              <AvatarImage
-                src={session.user.image ?? ""}
-                alt={session.user.name ?? ""}
-                className="rounded-full"
-              />
-              <AvatarFallback className="rounded-full">
-                {session.user.name?.charAt(0)}
-              </AvatarFallback>
-            </Avatar>
+            <ProfileAvatar
+              image={session.user.image}
+              name={session.user.name}
+              sizeClassName="size-10 shrink-0"
+              showAlert={Boolean(quota?.exceeded)}
+            />
             <div className="flex flex-col items-start text-left overflow-hidden">
               <p className="font-medium truncate w-full">{session.user.name}</p>
               <p className="text-xs text-muted-foreground truncate w-full">
@@ -199,17 +282,23 @@ export function UserProfileDesktop({ className }: { className?: string }) {
                   {session.user.email}
                 </p>
               </div>
-              <Avatar className="size-8">
-                <AvatarImage
-                  src={session.user.image ?? ""}
-                  alt={session.user.name ?? ""}
-                  className="rounded-full"
-                />
-                <AvatarFallback className="rounded-full">
-                  {session.user.name?.charAt(0)}
-                </AvatarFallback>
-              </Avatar>
+              <ProfileAvatar
+                image={session.user.image}
+                name={session.user.name}
+                sizeClassName="size-8"
+                showAlert={Boolean(quota?.exceeded)}
+              />
             </div>
+            {quota ? (
+              <div className="rounded-lg border p-3 text-xs text-muted-foreground">
+                <p className="font-medium text-foreground">{quota.planName} usage</p>
+                <p>{formatQuotaLine(quota.usage.contactsTotal, quota.limits.maxContactsTotal, "Contacts")}</p>
+                <p>{formatQuotaLine(quota.usage.newContactsThisMonth, quota.limits.maxNewContactsPerMonth, "New contacts this month")}</p>
+                <p>{formatQuotaLine(quota.usage.automationsTotal, quota.limits.maxAutomations, "Automations")}</p>
+                <p>{formatQuotaLine(quota.usage.sidekickSendsThisMonth, quota.limits.maxSidekickSendsPerMonth, "AI sends this month")}</p>
+                <p>{formatQuotaLine(quota.usage.sidekickChatPromptsThisMonth, quota.limits.maxSidekickChatPromptsPerMonth, "Sidekick chats this month")}</p>
+              </div>
+            ) : null}
           </div>
           {/* <DropdownMenuSeparator />
           <DropdownMenuItem className="cursor-pointer" asChild>

--- a/apps/app/src/lib/auth.ts
+++ b/apps/app/src/lib/auth.ts
@@ -5,6 +5,27 @@ import { db } from "@pilot/db";
 import { env } from "@/env";
 import { polarInstance } from "@/lib/polar/server";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
+import { getPaidPricingPlans } from "@/lib/constants/pricing";
+
+const checkoutProducts = getPaidPricingPlans().flatMap((plan) => {
+  const products: Array<{ productId: string; slug: string }> = [];
+
+  if (plan.polar.monthlyProductId && plan.polar.monthlySlug) {
+    products.push({
+      productId: plan.polar.monthlyProductId,
+      slug: plan.polar.monthlySlug,
+    });
+  }
+
+  if (plan.polar.yearlyProductId && plan.polar.yearlySlug) {
+    products.push({
+      productId: plan.polar.yearlyProductId,
+      slug: plan.polar.yearlySlug,
+    });
+  }
+
+  return products;
+});
 
 export const auth = betterAuth({
   baseURL:
@@ -39,24 +60,7 @@ export const auth = betterAuth({
       createCustomerOnSignUp: true,
       use: [
         checkout({
-          products: [
-            {
-              productId: "89404de5-5d64-45fd-872d-d5969cf059ce",
-              slug: "Pilot-Starter-Month",
-            },
-            {
-              productId: "640c8f73-66dd-43ab-83a3-ecf6e01bf01e",
-              slug: "Pilot-Starter-Annual",
-            },
-            {
-              productId: "b1b9e32b-9417-4e99-8142-11ee6ce45bdc",
-              slug: "Pilot-Premium-Month",
-            },
-            {
-              productId: "a9ad37ae-90cd-4c2e-8fd6-88a430f8afb6",
-              slug: "Pilot-Premium-Annual",
-            },
-          ],
+          products: checkoutProducts,
           authenticatedUsersOnly: true,
           successUrl: "/sidekick-onboarding",
         }),

--- a/apps/app/src/lib/billing/enforce.ts
+++ b/apps/app/src/lib/billing/enforce.ts
@@ -1,0 +1,203 @@
+import { getPricingPlan } from "@/lib/constants/pricing";
+import { getCurrentPlan } from "@/lib/billing/plan";
+import { getCurrentUsage } from "@/lib/billing/usage";
+import type {
+  BillingCapability,
+  BillingFlags,
+  BillingStatus,
+  BillingUsage,
+  BillingViolation,
+} from "@/lib/billing/types";
+
+export class BillingLimitError extends Error {
+  constructor(
+    public readonly code: BillingViolation["code"],
+    message: string,
+  ) {
+    super(message);
+    this.name = "BillingLimitError";
+  }
+}
+
+function isAtLimit(current: number, limit: number | null): boolean {
+  return limit !== null && current >= limit;
+}
+
+function isOverLimit(current: number, limit: number | null): boolean {
+  return limit !== null && current > limit;
+}
+
+function buildFlags(usage: BillingUsage, limits: BillingStatus["limits"]): BillingFlags {
+  const isStructurallyFrozen =
+    isOverLimit(usage.contactsTotal, limits.maxContactsTotal) ||
+    isOverLimit(usage.automationsTotal, limits.maxAutomations);
+
+  return {
+    isStructurallyFrozen,
+    canCreateContact:
+      !isStructurallyFrozen &&
+      !isAtLimit(usage.contactsTotal, limits.maxContactsTotal) &&
+      !isAtLimit(usage.newContactsThisMonth, limits.maxNewContactsPerMonth),
+    canMutateContacts: !isStructurallyFrozen,
+    canCreateAutomation:
+      !isStructurallyFrozen &&
+      !isAtLimit(usage.automationsTotal, limits.maxAutomations),
+    canMutateAutomations: !isStructurallyFrozen,
+    canUseSidekickChat:
+      !isStructurallyFrozen &&
+      !isAtLimit(
+        usage.sidekickChatPromptsThisMonth,
+        limits.maxSidekickChatPromptsPerMonth,
+      ),
+    canSendSidekickReply:
+      !isStructurallyFrozen &&
+      !isAtLimit(usage.sidekickSendsThisMonth, limits.maxSidekickSendsPerMonth),
+  };
+}
+
+export function getContactCreationViolation(
+  status: BillingStatus,
+): BillingViolation | null {
+  if (status.flags.isStructurallyFrozen) {
+    return {
+      code: "BILLING_STRUCTURALLY_FROZEN",
+      message:
+        "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+    };
+  }
+
+  if (isAtLimit(status.usage.contactsTotal, status.limits.maxContactsTotal)) {
+    return {
+      code: "BILLING_CONTACT_LIMIT_REACHED",
+      message:
+        "You have reached the maximum total contacts for your current plan.",
+    };
+  }
+
+  if (
+    isAtLimit(
+      status.usage.newContactsThisMonth,
+      status.limits.maxNewContactsPerMonth,
+    )
+  ) {
+    return {
+      code: "BILLING_NEW_CONTACT_LIMIT_REACHED",
+      message:
+        "You have reached the monthly new contact limit for your current plan.",
+    };
+  }
+
+  return null;
+}
+
+export function getAutomationCreationViolation(
+  status: BillingStatus,
+): BillingViolation | null {
+  if (status.flags.isStructurallyFrozen) {
+    return {
+      code: "BILLING_STRUCTURALLY_FROZEN",
+      message:
+        "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+    };
+  }
+
+  if (isAtLimit(status.usage.automationsTotal, status.limits.maxAutomations)) {
+    return {
+      code: "BILLING_AUTOMATION_LIMIT_REACHED",
+      message:
+        "You have reached the maximum number of automations for your current plan.",
+    };
+  }
+
+  return null;
+}
+
+export function getBillingViolation(
+  status: BillingStatus,
+  capability: BillingCapability,
+): BillingViolation | null {
+  switch (capability) {
+    case "contact:create":
+      return getContactCreationViolation(status);
+    case "contact:mutate":
+      return status.flags.canMutateContacts
+        ? null
+        : {
+            code: "BILLING_STRUCTURALLY_FROZEN",
+            message:
+              "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+          };
+    case "automation:create":
+      return getAutomationCreationViolation(status);
+    case "automation:mutate":
+      return status.flags.canMutateAutomations
+        ? null
+        : {
+            code: "BILLING_STRUCTURALLY_FROZEN",
+            message:
+              "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+          };
+    case "sidekick:chat":
+      if (status.flags.isStructurallyFrozen) {
+        return {
+          code: "BILLING_STRUCTURALLY_FROZEN",
+          message:
+            "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+        };
+      }
+      return status.flags.canUseSidekickChat
+        ? null
+        : {
+            code: "BILLING_SIDEKICK_CHAT_LIMIT_REACHED",
+            message:
+              "You have reached the monthly Sidekick chat limit for your current plan.",
+          };
+    case "sidekick:send":
+      if (status.flags.isStructurallyFrozen) {
+        return {
+          code: "BILLING_STRUCTURALLY_FROZEN",
+          message:
+            "Your workspace is frozen because it is above the current plan cap. Existing data is still visible, but changes are blocked until you upgrade or reduce usage.",
+        };
+      }
+      return status.flags.canSendSidekickReply
+        ? null
+        : {
+            code: "BILLING_SIDEKICK_SEND_LIMIT_REACHED",
+            message:
+              "You have reached the monthly Sidekick send limit for your current plan.",
+          };
+    default:
+      return null;
+  }
+}
+
+export async function getBillingStatus(
+  userId: string,
+  now: Date = new Date(),
+): Promise<BillingStatus> {
+  const planId = await getCurrentPlan(userId);
+  const plan = getPricingPlan(planId);
+  const usage = await getCurrentUsage(userId, now);
+
+  return {
+    planId,
+    limits: plan.limits,
+    usage,
+    flags: buildFlags(usage, plan.limits),
+  };
+}
+
+export async function assertBillingAllowed(
+  userId: string,
+  capability: BillingCapability,
+): Promise<BillingStatus> {
+  const status = await getBillingStatus(userId);
+  const violation = getBillingViolation(status, capability);
+
+  if (violation) {
+    throw new BillingLimitError(violation.code, violation.message);
+  }
+
+  return status;
+}

--- a/apps/app/src/lib/billing/plan.ts
+++ b/apps/app/src/lib/billing/plan.ts
@@ -1,0 +1,24 @@
+import { polarInstance } from "@/lib/polar/server";
+import {
+  type PlanId,
+  getPricingPlan,
+  resolvePlanIdFromProductId,
+} from "@/lib/constants/pricing";
+
+export async function getCurrentPlan(userId: string): Promise<PlanId> {
+  try {
+    const customerState = await polarInstance.customers.getStateExternal({
+      externalId: userId,
+    });
+    const activeProductId = customerState.activeSubscriptions?.[0]?.productId;
+
+    return resolvePlanIdFromProductId(activeProductId);
+  } catch (error) {
+    console.error("Failed to resolve Polar plan, defaulting to free", error);
+    return "free";
+  }
+}
+
+export function getPlanLimits(planId: PlanId) {
+  return getPricingPlan(planId).limits;
+}

--- a/apps/app/src/lib/billing/types.ts
+++ b/apps/app/src/lib/billing/types.ts
@@ -1,0 +1,47 @@
+import type { BillingLimits, PlanId } from "@/lib/constants/pricing";
+
+export type BillingCapability =
+  | "contact:create"
+  | "contact:mutate"
+  | "automation:create"
+  | "automation:mutate"
+  | "sidekick:chat"
+  | "sidekick:send";
+
+export type BillingLimitErrorCode =
+  | "BILLING_STRUCTURALLY_FROZEN"
+  | "BILLING_CONTACT_LIMIT_REACHED"
+  | "BILLING_NEW_CONTACT_LIMIT_REACHED"
+  | "BILLING_AUTOMATION_LIMIT_REACHED"
+  | "BILLING_SIDEKICK_SEND_LIMIT_REACHED"
+  | "BILLING_SIDEKICK_CHAT_LIMIT_REACHED";
+
+export interface BillingUsage {
+  contactsTotal: number;
+  newContactsThisMonth: number;
+  automationsTotal: number;
+  sidekickSendsThisMonth: number;
+  sidekickChatPromptsThisMonth: number;
+}
+
+export interface BillingFlags {
+  isStructurallyFrozen: boolean;
+  canCreateContact: boolean;
+  canMutateContacts: boolean;
+  canCreateAutomation: boolean;
+  canMutateAutomations: boolean;
+  canUseSidekickChat: boolean;
+  canSendSidekickReply: boolean;
+}
+
+export interface BillingStatus {
+  planId: PlanId;
+  limits: BillingLimits;
+  usage: BillingUsage;
+  flags: BillingFlags;
+}
+
+export interface BillingViolation {
+  code: BillingLimitErrorCode;
+  message: string;
+}

--- a/apps/app/src/lib/billing/usage.ts
+++ b/apps/app/src/lib/billing/usage.ts
@@ -1,0 +1,80 @@
+import { db } from "@pilot/db";
+import {
+  automation,
+  billingUsageEvent,
+  contact,
+  sidekickActionLog,
+} from "@pilot/db/schema";
+import { and, eq, gte, sql } from "drizzle-orm";
+import type { BillingUsage } from "@/lib/billing/types";
+
+export function getStartOfCurrentUtcMonth(now: Date = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
+}
+
+async function countRows(source: any, whereClause?: any) {
+  const query = db.select({
+    count: sql<number>`count(*)::int`,
+  }).from(source);
+
+  const rows = whereClause ? await query.where(whereClause) : await query;
+  return rows[0]?.count ?? 0;
+}
+
+export async function getCurrentUsage(
+  userId: string,
+  now: Date = new Date(),
+): Promise<BillingUsage> {
+  const monthStart = getStartOfCurrentUtcMonth(now);
+
+  const [
+    contactsTotal,
+    newContactsThisMonth,
+    automationsTotal,
+    sidekickSendsThisMonth,
+    sidekickChatPromptsThisMonth,
+  ] = await Promise.all([
+    countRows(contact, eq(contact.userId, userId)),
+    countRows(
+      contact,
+      and(eq(contact.userId, userId), gte(contact.createdAt, monthStart)),
+    ),
+    countRows(automation, eq(automation.userId, userId)),
+    countRows(
+      sidekickActionLog,
+      and(
+        eq(sidekickActionLog.userId, userId),
+        gte(sidekickActionLog.createdAt, monthStart),
+      ),
+    ),
+    countRows(
+      billingUsageEvent,
+      and(
+        eq(billingUsageEvent.userId, userId),
+        eq(billingUsageEvent.kind, "sidekick_chat_prompt"),
+        gte(billingUsageEvent.createdAt, monthStart),
+      ),
+    ),
+  ]);
+
+  return {
+    contactsTotal,
+    newContactsThisMonth,
+    automationsTotal,
+    sidekickSendsThisMonth,
+    sidekickChatPromptsThisMonth,
+  };
+}
+
+export async function recordSidekickChatPromptUsage(
+  userId: string,
+  referenceId?: string,
+): Promise<void> {
+  await db.insert(billingUsageEvent).values({
+    id: crypto.randomUUID(),
+    userId,
+    kind: "sidekick_chat_prompt",
+    referenceId: referenceId ?? null,
+    createdAt: new Date(),
+  });
+}

--- a/apps/app/src/lib/billing/usage.ts
+++ b/apps/app/src/lib/billing/usage.ts
@@ -69,12 +69,24 @@ export async function getCurrentUsage(
 export async function recordSidekickChatPromptUsage(
   userId: string,
   referenceId?: string,
-): Promise<void> {
+): Promise<string> {
+  const eventId = crypto.randomUUID();
+
   await db.insert(billingUsageEvent).values({
-    id: crypto.randomUUID(),
+    id: eventId,
     userId,
     kind: "sidekick_chat_prompt",
     referenceId: referenceId ?? null,
     createdAt: new Date(),
   });
+
+  return eventId;
+}
+
+export async function rollbackSidekickChatPromptUsage(
+  usageEventId: string,
+): Promise<void> {
+  await db
+    .delete(billingUsageEvent)
+    .where(eq(billingUsageEvent.id, usageEventId));
 }

--- a/apps/app/src/lib/billing/usage.ts
+++ b/apps/app/src/lib/billing/usage.ts
@@ -69,24 +69,12 @@ export async function getCurrentUsage(
 export async function recordSidekickChatPromptUsage(
   userId: string,
   referenceId?: string,
-): Promise<string> {
-  const eventId = crypto.randomUUID();
-
+): Promise<void> {
   await db.insert(billingUsageEvent).values({
-    id: eventId,
+    id: crypto.randomUUID(),
     userId,
     kind: "sidekick_chat_prompt",
     referenceId: referenceId ?? null,
     createdAt: new Date(),
   });
-
-  return eventId;
-}
-
-export async function rollbackSidekickChatPromptUsage(
-  usageEventId: string,
-): Promise<void> {
-  await db
-    .delete(billingUsageEvent)
-    .where(eq(billingUsageEvent.id, usageEventId));
 }

--- a/apps/app/src/lib/constants/pricing.ts
+++ b/apps/app/src/lib/constants/pricing.ts
@@ -28,6 +28,34 @@ export interface PricingPlan {
   limits: BillingLimits;
 }
 
+function formatLimitValue(value: number | null, singular: string): string {
+  if (value === null) {
+    return `Unlimited ${singular}s`;
+  }
+
+  return `Up to ${value.toLocaleString()} ${singular}${value === 1 ? "" : "s"}`;
+}
+
+function getPlanFeaturesFromLimits(limits: BillingLimits): string[] {
+  return [
+    formatLimitValue(limits.maxContactsTotal, "contact"),
+    limits.maxAutomations === null
+      ? "Unlimited automations"
+      : `Up to ${limits.maxAutomations.toLocaleString()} automation${
+          limits.maxAutomations === 1 ? "" : "s"
+        }`,
+    limits.maxNewContactsPerMonth === null
+      ? "Unlimited new contacts per month"
+      : `Up to ${limits.maxNewContactsPerMonth.toLocaleString()} new contacts per month`,
+    limits.maxSidekickSendsPerMonth === null
+      ? "Unlimited AI sends per month"
+      : `Up to ${limits.maxSidekickSendsPerMonth.toLocaleString()} AI sends per month`,
+    limits.maxSidekickChatPromptsPerMonth === null
+      ? "Unlimited Sidekick chats per month"
+      : `Up to ${limits.maxSidekickChatPromptsPerMonth.toLocaleString()} Sidekick chats per month`,
+  ];
+}
+
 export const pricingPlans: PricingPlan[] = [
   {
     planId: "free",
@@ -37,13 +65,13 @@ export const pricingPlans: PricingPlan[] = [
     yearlyPriceCents: null,
     displayMonthlyPrice: "$0",
     displayYearlyPrice: null,
-    features: [
-      "Max 100 contacts",
-      "1 automation flow",
-      "3 AI sends per month",
-      "Basic Sidekick and automation access",
-      "3 day analytics",
-    ],
+    features: getPlanFeaturesFromLimits({
+      maxContactsTotal: 50,
+      maxNewContactsPerMonth: 10,
+      maxAutomations: 1,
+      maxSidekickSendsPerMonth: 10,
+      maxSidekickChatPromptsPerMonth: 3,
+    }),
     polar: {
       monthlyProductId: null,
       monthlySlug: null,
@@ -51,11 +79,11 @@ export const pricingPlans: PricingPlan[] = [
       yearlySlug: null,
     },
     limits: {
-      maxContactsTotal: 100,
-      maxNewContactsPerMonth: 25, // TODO: tune this placeholder
+      maxContactsTotal: 50,
+      maxNewContactsPerMonth: 10,
       maxAutomations: 1,
-      maxSidekickSendsPerMonth: 3,
-      maxSidekickChatPromptsPerMonth: 5, // TODO: tune this placeholder
+      maxSidekickSendsPerMonth: 10,
+      maxSidekickChatPromptsPerMonth: 3,
     },
   },
   {
@@ -67,13 +95,13 @@ export const pricingPlans: PricingPlan[] = [
     displayMonthlyPrice: "$19",
     displayYearlyPrice: "$15.20",
     highlighted: true,
-    features: [
-      "Max 500 contacts",
-      "3 automation flows",
-      "100 Sidekick chat prompts per month",
-      "Drafting only, no in-app sends",
-      "14 day analytics",
-    ],
+    features: getPlanFeaturesFromLimits({
+      maxContactsTotal: 2000,
+      maxNewContactsPerMonth: 500,
+      maxAutomations: 3,
+      maxSidekickSendsPerMonth: 1000,
+      maxSidekickChatPromptsPerMonth: 100,
+    }),
     polar: {
       monthlyProductId: "735f6aeb-6071-4dd0-a777-af4b34b1df86",
       monthlySlug: "starter-monthly",
@@ -81,10 +109,10 @@ export const pricingPlans: PricingPlan[] = [
       yearlySlug: "starter-yearly",
     },
     limits: {
-      maxContactsTotal: 500,
-      maxNewContactsPerMonth: 100, // TODO: tune this placeholder
+      maxContactsTotal: 2000,
+      maxNewContactsPerMonth: 500,
       maxAutomations: 3,
-      maxSidekickSendsPerMonth: 0,
+      maxSidekickSendsPerMonth: 1000,
       maxSidekickChatPromptsPerMonth: 100,
     },
   },
@@ -96,13 +124,13 @@ export const pricingPlans: PricingPlan[] = [
     yearlyPriceCents: 3120,
     displayMonthlyPrice: "$39",
     displayYearlyPrice: "$31.20",
-    features: [
-      "Max 5,000 contacts",
-      "Unlimited automation count",
-      "300 Sidekick chat prompts per month",
-      "Drafting only, no in-app sends",
-      "30 day analytics",
-    ],
+    features: getPlanFeaturesFromLimits({
+      maxContactsTotal: 5000,
+      maxNewContactsPerMonth: 2000,
+      maxAutomations: null,
+      maxSidekickSendsPerMonth: 2500,
+      maxSidekickChatPromptsPerMonth: 300,
+    }),
     polar: {
       monthlyProductId: "55f0cbfe-8ce4-48f0-bf6b-4cd2f0421cab",
       monthlySlug: "growth-monthly",
@@ -111,9 +139,9 @@ export const pricingPlans: PricingPlan[] = [
     },
     limits: {
       maxContactsTotal: 5000,
-      maxNewContactsPerMonth: 1000, // TODO: tune this placeholder
+      maxNewContactsPerMonth: 2000,
       maxAutomations: null,
-      maxSidekickSendsPerMonth: 0,
+      maxSidekickSendsPerMonth: 2500,
       maxSidekickChatPromptsPerMonth: 300,
     },
   },
@@ -125,13 +153,13 @@ export const pricingPlans: PricingPlan[] = [
     yearlyPriceCents: 3920,
     displayMonthlyPrice: "$49",
     displayYearlyPrice: "$39.20",
-    features: [
-      "Max 50,000 contacts",
-      "Unlimited automation count",
-      "Unlimited Sidekick usage",
-      "Priority support",
-      "Full analytics",
-    ],
+    features: getPlanFeaturesFromLimits({
+      maxContactsTotal: 10000,
+      maxNewContactsPerMonth: 5000,
+      maxAutomations: null,
+      maxSidekickSendsPerMonth: 6000,
+      maxSidekickChatPromptsPerMonth: 500,
+    }),
     polar: {
       monthlyProductId: "8eb0a30e-fa30-4cbd-81dd-d03496041c85",
       monthlySlug: "pro-monthly",
@@ -139,11 +167,11 @@ export const pricingPlans: PricingPlan[] = [
       yearlySlug: "pro-yearly",
     },
     limits: {
-      maxContactsTotal: 50000,
-      maxNewContactsPerMonth: 10000, // TODO: tune this placeholder
+      maxContactsTotal: 10000,
+      maxNewContactsPerMonth: 5000,
       maxAutomations: null,
-      maxSidekickSendsPerMonth: null,
-      maxSidekickChatPromptsPerMonth: null,
+      maxSidekickSendsPerMonth: 6000,
+      maxSidekickChatPromptsPerMonth: 500,
     },
   },
 ];

--- a/apps/app/src/lib/constants/pricing.ts
+++ b/apps/app/src/lib/constants/pricing.ts
@@ -1,39 +1,216 @@
+export type PlanId = "free" | "starter" | "growth" | "pro";
+export type PaidPlanId = Exclude<PlanId, "free">;
+
+export interface BillingLimits {
+  maxContactsTotal: number | null;
+  maxNewContactsPerMonth: number | null;
+  maxAutomations: number | null;
+  maxSidekickSendsPerMonth: number | null;
+  maxSidekickChatPromptsPerMonth: number | null;
+}
+
 export interface PricingPlan {
+  planId: PlanId;
   title: string;
-  monthlyPrice: string;
-  yearlyPrice: string;
   description: string;
+  monthlyPriceCents: number;
+  yearlyPriceCents: number | null;
+  displayMonthlyPrice: string;
+  displayYearlyPrice: string | null;
   features: string[];
   highlighted?: boolean;
+  polar: {
+    monthlyProductId: string | null;
+    monthlySlug: string | null;
+    yearlyProductId: string | null;
+    yearlySlug: string | null;
+  };
+  limits: BillingLimits;
 }
 
 export const pricingPlans: PricingPlan[] = [
   {
-    title: "Starter",
-    description: "For solo creators and small teams",
-    monthlyPrice: "$35",
-    yearlyPrice: "$29",
-    highlighted: true,
+    planId: "free",
+    title: "Free",
+    description: "Use the core workflow with strict caps.",
+    monthlyPriceCents: 0,
+    yearlyPriceCents: null,
+    displayMonthlyPrice: "$0",
+    displayYearlyPrice: null,
     features: [
-      "Lead tagging and scoring",
-      "AI-assisted DM replies",
-      "Contacts and conversation history",
-      "Follow-up suggestions",
-      "Email support",
+      "Max 100 contacts",
+      "1 automation flow",
+      "3 AI sends per month",
+      "Basic Sidekick and automation access",
+      "3 day analytics",
     ],
+    polar: {
+      monthlyProductId: null,
+      monthlySlug: null,
+      yearlyProductId: null,
+      yearlySlug: null,
+    },
+    limits: {
+      maxContactsTotal: 100,
+      maxNewContactsPerMonth: 25, // TODO: tune this placeholder
+      maxAutomations: 1,
+      maxSidekickSendsPerMonth: 3,
+      maxSidekickChatPromptsPerMonth: 5, // TODO: tune this placeholder
+    },
   },
   {
-    title: "Premium",
-    description: "For growing teams with higher volume",
-    monthlyPrice: "$59",
-    yearlyPrice: "$49",
+    planId: "starter",
+    title: "Starter",
+    description: "For creators handling a modest volume.",
+    monthlyPriceCents: 1900,
+    yearlyPriceCents: null,
+    displayMonthlyPrice: "$19",
+    displayYearlyPrice: null,
+    highlighted: true,
     features: [
-      "Everything in Starter, plus:",
-      "Priority lead views",
-      "Advanced performance insights",
-      "Payment platform sync",
-      "More AI automation capacity",
-      "Priority support",
+      "Max 500 contacts",
+      "3 automation flows",
+      "100 Sidekick chat prompts per month",
+      "Drafting only, no in-app sends",
+      "14 day analytics",
     ],
+    polar: {
+      monthlyProductId: null, // TODO: set after creating the Polar product
+      monthlySlug: null, // TODO: set after creating the Polar product
+      yearlyProductId: null, // TODO: set if you add a yearly product
+      yearlySlug: null, // TODO: set if you add a yearly product
+    },
+    limits: {
+      maxContactsTotal: 500,
+      maxNewContactsPerMonth: 100, // TODO: tune this placeholder
+      maxAutomations: 3,
+      maxSidekickSendsPerMonth: 0,
+      maxSidekickChatPromptsPerMonth: 100,
+    },
+  },
+  {
+    planId: "growth",
+    title: "Growth",
+    description: "For growing teams that need more headroom.",
+    monthlyPriceCents: 3900,
+    yearlyPriceCents: null,
+    displayMonthlyPrice: "$39",
+    displayYearlyPrice: null,
+    features: [
+      "Max 5,000 contacts",
+      "Unlimited automation count",
+      "300 Sidekick chat prompts per month",
+      "Drafting only, no in-app sends",
+      "30 day analytics",
+    ],
+    polar: {
+      monthlyProductId: null, // TODO: set after creating the Polar product
+      monthlySlug: null, // TODO: set after creating the Polar product
+      yearlyProductId: null, // TODO: set if you add a yearly product
+      yearlySlug: null, // TODO: set if you add a yearly product
+    },
+    limits: {
+      maxContactsTotal: 5000,
+      maxNewContactsPerMonth: 1000, // TODO: tune this placeholder
+      maxAutomations: null,
+      maxSidekickSendsPerMonth: 0,
+      maxSidekickChatPromptsPerMonth: 300,
+    },
+  },
+  {
+    planId: "pro",
+    title: "Pro",
+    description: "For high-volume teams that need the full range.",
+    monthlyPriceCents: 4900,
+    yearlyPriceCents: null,
+    displayMonthlyPrice: "$49",
+    displayYearlyPrice: null,
+    features: [
+      "Max 50,000 contacts",
+      "Unlimited automation count",
+      "Unlimited Sidekick usage",
+      "Priority support",
+      "Full analytics",
+    ],
+    polar: {
+      monthlyProductId: null, // TODO: set after creating the Polar product
+      monthlySlug: null, // TODO: set after creating the Polar product
+      yearlyProductId: null, // TODO: set if you add a yearly product
+      yearlySlug: null, // TODO: set if you add a yearly product
+    },
+    limits: {
+      maxContactsTotal: 50000,
+      maxNewContactsPerMonth: 10000, // TODO: tune this placeholder
+      maxAutomations: null,
+      maxSidekickSendsPerMonth: null,
+      maxSidekickChatPromptsPerMonth: null,
+    },
   },
 ];
+
+export const pricingPlanMap = pricingPlans.reduce(
+  (acc, plan) => {
+    acc[plan.planId] = plan;
+    return acc;
+  },
+  {} as Record<PlanId, PricingPlan>,
+);
+
+export function getPricingPlan(planId: PlanId): PricingPlan {
+  return pricingPlanMap[planId];
+}
+
+export function getPaidPricingPlans(): PricingPlan[] {
+  return pricingPlans.filter((plan) => plan.planId !== "free");
+}
+
+export function isPaidPlanId(planId: PlanId): planId is PaidPlanId {
+  return planId !== "free";
+}
+
+export function resolvePlanIdFromProductId(
+  productId: string | null | undefined,
+): PlanId {
+  if (!productId) {
+    return "free";
+  }
+
+  const matchedPlan = getPaidPricingPlans().find(
+    (plan) =>
+      plan.polar.monthlyProductId === productId ||
+      plan.polar.yearlyProductId === productId,
+  );
+
+  return matchedPlan?.planId ?? "free";
+}
+
+export function getCheckoutConfig(
+  planId: PaidPlanId,
+  isYearly: boolean,
+): { slug: string; productId: string } | null {
+  const plan = getPricingPlan(planId);
+  const slug = isYearly ? plan.polar.yearlySlug : plan.polar.monthlySlug;
+  const productId = isYearly
+    ? plan.polar.yearlyProductId
+    : plan.polar.monthlyProductId;
+
+  if (!slug || !productId) {
+    return null;
+  }
+
+  return { slug, productId };
+}
+
+export function hasAnyYearlyPricing(): boolean {
+  return getPaidPricingPlans().some(
+    (plan) => plan.yearlyPriceCents !== null && plan.displayYearlyPrice !== null,
+  );
+}
+
+export function formatPlanPrice(plan: PricingPlan, isYearly: boolean): string {
+  if (isYearly && plan.displayYearlyPrice) {
+    return plan.displayYearlyPrice;
+  }
+
+  return plan.displayMonthlyPrice;
+}

--- a/apps/app/src/lib/constants/pricing.ts
+++ b/apps/app/src/lib/constants/pricing.ts
@@ -63,9 +63,9 @@ export const pricingPlans: PricingPlan[] = [
     title: "Starter",
     description: "For creators handling a modest volume.",
     monthlyPriceCents: 1900,
-    yearlyPriceCents: null,
+    yearlyPriceCents: 1520,
     displayMonthlyPrice: "$19",
-    displayYearlyPrice: null,
+    displayYearlyPrice: "$15.20",
     highlighted: true,
     features: [
       "Max 500 contacts",
@@ -75,10 +75,10 @@ export const pricingPlans: PricingPlan[] = [
       "14 day analytics",
     ],
     polar: {
-      monthlyProductId: null, // TODO: set after creating the Polar product
-      monthlySlug: null, // TODO: set after creating the Polar product
-      yearlyProductId: null, // TODO: set if you add a yearly product
-      yearlySlug: null, // TODO: set if you add a yearly product
+      monthlyProductId: "735f6aeb-6071-4dd0-a777-af4b34b1df86",
+      monthlySlug: "starter-monthly",
+      yearlyProductId: "c7c3c1c6-2050-46ab-b5af-f9c3b3230507",
+      yearlySlug: "starter-yearly",
     },
     limits: {
       maxContactsTotal: 500,
@@ -93,9 +93,9 @@ export const pricingPlans: PricingPlan[] = [
     title: "Growth",
     description: "For growing teams that need more headroom.",
     monthlyPriceCents: 3900,
-    yearlyPriceCents: null,
+    yearlyPriceCents: 3120,
     displayMonthlyPrice: "$39",
-    displayYearlyPrice: null,
+    displayYearlyPrice: "$31.20",
     features: [
       "Max 5,000 contacts",
       "Unlimited automation count",
@@ -104,10 +104,10 @@ export const pricingPlans: PricingPlan[] = [
       "30 day analytics",
     ],
     polar: {
-      monthlyProductId: null, // TODO: set after creating the Polar product
-      monthlySlug: null, // TODO: set after creating the Polar product
-      yearlyProductId: null, // TODO: set if you add a yearly product
-      yearlySlug: null, // TODO: set if you add a yearly product
+      monthlyProductId: "55f0cbfe-8ce4-48f0-bf6b-4cd2f0421cab",
+      monthlySlug: "growth-monthly",
+      yearlyProductId: "0e7bf5dd-2054-4a66-aa75-210a29774401",
+      yearlySlug: "growth-yearly",
     },
     limits: {
       maxContactsTotal: 5000,
@@ -122,9 +122,9 @@ export const pricingPlans: PricingPlan[] = [
     title: "Pro",
     description: "For high-volume teams that need the full range.",
     monthlyPriceCents: 4900,
-    yearlyPriceCents: null,
+    yearlyPriceCents: 3920,
     displayMonthlyPrice: "$49",
-    displayYearlyPrice: null,
+    displayYearlyPrice: "$39.20",
     features: [
       "Max 50,000 contacts",
       "Unlimited automation count",
@@ -133,10 +133,10 @@ export const pricingPlans: PricingPlan[] = [
       "Full analytics",
     ],
     polar: {
-      monthlyProductId: null, // TODO: set after creating the Polar product
-      monthlySlug: null, // TODO: set after creating the Polar product
-      yearlyProductId: null, // TODO: set if you add a yearly product
-      yearlySlug: null, // TODO: set if you add a yearly product
+      monthlyProductId: "8eb0a30e-fa30-4cbd-81dd-d03496041c85",
+      monthlySlug: "pro-monthly",
+      yearlyProductId: "e78999c4-f0ec-4c11-9595-2df220c5a95c",
+      yearlySlug: "pro-yearly",
     },
     limits: {
       maxContactsTotal: 50000,

--- a/apps/app/src/lib/inngest/functions.ts
+++ b/apps/app/src/lib/inngest/functions.ts
@@ -10,6 +10,7 @@ import {
   summarizeContacts,
 } from "@pilot/core/contacts/sync";
 import { inngest } from "./client";
+import { getBillingStatus } from "@/lib/billing/enforce";
 
 export const syncInstagramContacts = inngest.createFunction(
   {
@@ -55,10 +56,12 @@ export const syncInstagramContacts = inngest.createFunction(
       "fetch-contacts",
       async (): Promise<ContactsResult> => {
         try {
+          const billing = await getBillingStatus(userId);
           const contacts = await fetchAndStoreInstagramContacts({
             dbClient: db,
             userId,
             fullSync,
+            billing,
           });
 
           if (!Array.isArray(contacts)) {

--- a/apps/app/src/lib/polar/client.ts
+++ b/apps/app/src/lib/polar/client.ts
@@ -1,35 +1,28 @@
 import { authClient } from "../auth-client";
+import {
+  type PaidPlanId,
+  getCheckoutConfig,
+  getPricingPlan,
+} from "@/lib/constants/pricing";
 
-type PlanTitle = "Starter" | "Premium";
+export async function handleCheckout(planId: PaidPlanId, isYearly: boolean) {
+  const checkoutConfig = getCheckoutConfig(planId, isYearly);
 
-const productMap: Record<PlanTitle, { monthly: string; yearly: string }> = {
-  Starter: {
-    monthly: "Pilot-Starter-Month",
-    yearly: "Pilot-Starter-Annual",
-  },
-  Premium: {
-    monthly: "Pilot-Premium-Month",
-    yearly: "Pilot-Premium-Annual",
-  },
-};
-
-export async function handleCheckout(planTitle: PlanTitle, isYearly: boolean) {
-  const plan = productMap[planTitle];
-  if (!plan)
+  if (!checkoutConfig) {
+    const plan = getPricingPlan(planId);
     throw new Error(
-      `Invalid plan title: ${planTitle}. Valid options are: ${Object.keys(
-        productMap
-      ).join(", ")}`
+      `${plan.title} ${isYearly ? "yearly" : "monthly"} checkout is not configured in pricing.ts yet.`,
     );
-  const productId = isYearly ? plan.yearly : plan.monthly;
+  }
+
   try {
-    await authClient.checkout({ slug: productId });
+    await authClient.checkout({ slug: checkoutConfig.slug });
   } catch (error) {
     console.error("Checkout error:", error);
     throw new Error(
-      `Checkout failed for ${planTitle} (${isYearly ? "yearly" : "monthly"}): ${
+      `Checkout failed for ${planId} (${isYearly ? "yearly" : "monthly"}): ${
         error instanceof Error ? error.message : "Unknown error"
-      }`
+      }`,
     );
   }
 }

--- a/docs/polar-tier-enforcement.md
+++ b/docs/polar-tier-enforcement.md
@@ -1,0 +1,358 @@
+# Polar Tier Enforcement Plan
+
+## Execution Tracker
+
+### Phase 1: Planning Breakdown
+
+- [x] Convert this plan into an implementation checklist with phased todos
+- [x] Keep this checklist updated as tasks are completed
+
+### Phase 2: Pricing Catalog and Billing Foundation
+
+- [x] Refactor `apps/app/src/lib/constants/pricing.ts` into the tier source of truth
+- [x] Remove hardcoded plan mappings from checkout, badge, and upgrade UI
+- [x] Add app billing resolver/service modules for plan resolution, usage counting, and enforcement
+
+### Phase 3: Database and Usage Ledger
+
+- [x] Add `billing_usage_event` to `packages/db/src/schema.ts`
+- [x] Generate and commit the new Drizzle migration artifacts
+
+### Phase 4: Server-Side Enforcement
+
+- [x] Enforce billing limits in automation actions
+- [x] Enforce billing limits in contact actions and sync trigger entrypoints
+- [x] Enforce billing limits in the Sidekick chat API
+- [x] Enforce billing limits in the background contact sync path
+- [x] Enforce billing limits in the Instagram webhook auto-reply path
+
+### Phase 5: UI Gating and Operator Docs
+
+- [x] Add minimal UI billing-state gating for Sidekick, Contacts, and Automations
+- [x] Add `docs/polar-product-setup.md`
+
+### Phase 6: Validation and Wrap-Up
+
+- [x] Run targeted type/build validation
+- [x] Mark all completed tasks in this checklist
+
+## Summary
+
+Implement a single app-owned billing enforcement layer that uses Polar as the source of subscription truth and `pricing.ts` as the source of tier configuration. The app will treat users with no active subscription as the `free` tier, enforce only numeric caps in this pass, and keep over-limit accounts read-only/frozen for existing data.
+
+This pass stays inside the current app scope only: contacts, Sidekick chat/DM/comment reply, and automations. It does not implement analytics/support/community/custom-webhook gating yet.
+
+## Implementation
+
+### 1. Replace the pricing catalog with a real tier model
+
+Update [pricing.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/lib/constants/pricing.ts) so it becomes the single source of truth for both UI and enforcement.
+
+Add a new tier shape like:
+
+- `planId`: `"free" | "starter" | "growth" | "pro"`
+- `title`
+- `monthlyPriceCents`
+- `displayMonthlyPrice`
+- `description`
+- `features`
+- `polar`: `{ monthlyProductId?: string; monthlySlug?: string; yearlyProductId?: string; yearlySlug?: string }`
+- `limits`: `{ maxContactsTotal: number | null; maxNewContactsPerMonth: number | null; maxAutomations: number | null; maxSidekickSendsPerMonth: number | null; maxSidekickChatPromptsPerMonth: number | null }`
+
+Replace the current stale `Starter`/`Premium` display data with `Free`, `Starter`, `Growth`, and `Pro`.
+
+Use these default values so the code is fully wired immediately, with the explicitly ambiguous ones marked `TODO` in the constants file for you to edit later:
+
+- `free`
+  - `maxContactsTotal: 100`
+  - `maxAutomations: 1`
+  - `maxSidekickSendsPerMonth: 3`
+  - `maxSidekickChatPromptsPerMonth: 5` (placeholder)
+  - `maxNewContactsPerMonth: 25` (placeholder)
+- `starter`
+  - `maxContactsTotal: 500`
+  - `maxAutomations: 3`
+  - `maxSidekickSendsPerMonth: 0` (matches your “draft only, no send” copy)
+  - `maxSidekickChatPromptsPerMonth: 100`
+  - `maxNewContactsPerMonth: 100` (placeholder)
+- `growth`
+  - `maxContactsTotal: 5000`
+  - `maxAutomations: null`
+  - `maxSidekickSendsPerMonth: 0` (matches your “draft only, no send” copy)
+  - `maxSidekickChatPromptsPerMonth: 300`
+  - `maxNewContactsPerMonth: 1000` (placeholder)
+- `pro`
+  - `maxContactsTotal: 50000`
+  - `maxAutomations: null`
+  - `maxSidekickSendsPerMonth: null`
+  - `maxSidekickChatPromptsPerMonth: null`
+  - `maxNewContactsPerMonth: 10000` (placeholder)
+
+### 2. Eliminate hardcoded plan mappings everywhere
+
+Refactor these files to read from the pricing catalog instead of duplicating product IDs, titles, or slugs:
+
+- [auth.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/lib/auth.ts)
+- [client.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/lib/polar/client.ts)
+- [subscription-badge.tsx](C:/Users/USER/Desktop/code/pilot/apps/app/src/components/subscription-badge.tsx)
+- [page.tsx](C:/Users/USER/Desktop/code/pilot/apps/app/src/app/(dashboard)/(account)/upgrade/page.tsx)
+
+Changes:
+
+- `auth.ts`
+  - Build the Better Auth `checkout({ products: [...] })` list from `pricing.ts`.
+  - Exclude `free` from checkout products.
+- `lib/polar/client.ts`
+  - Replace `PlanTitle = "Starter" | "Premium"` with `PlanId = "starter" | "growth" | "pro"`.
+  - Reject checkout for `free`.
+  - Resolve slug from `pricing.ts`.
+- `subscription-badge.tsx`
+  - Map `activeSubscriptions[0].productId` to plan ID using the `pricing.ts` product IDs.
+  - Fallback to `free` if no active subscription.
+- Upgrade page
+  - Render all four plans from `pricing.ts`.
+  - `free` renders as informational only, no checkout button.
+  - Paid tiers use the centralized checkout metadata.
+
+### 3. Add a server-side billing resolver and enforcement service
+
+Create a new server-only module, for example:
+
+- `apps/app/src/lib/billing/plan.ts`
+- `apps/app/src/lib/billing/usage.ts`
+- `apps/app/src/lib/billing/enforce.ts`
+
+Core responsibilities:
+
+- `getCurrentPlan(userId)`
+  - Call `polarInstance.customers.getStateExternal({ externalId: userId })`.
+  - Read `activeSubscriptions`.
+  - Map the active product ID to a plan ID using `pricing.ts`.
+  - If no active subscription, return `free`.
+- `getCurrentUsage(userId, now)`
+  - `contactsTotal`: count rows in `contact`
+  - `newContactsThisMonth`: count `contact.createdAt >= startOfUtcMonth`
+  - `automationsTotal`: count rows in `automation`
+  - `sidekickSendsThisMonth`: count rows in `sidekickActionLog.createdAt >= startOfUtcMonth`
+  - `sidekickChatPromptsThisMonth`: count rows in a new usage-event table (see step 4)
+- `getBillingStatus(userId)`
+  - Returns `{ planId, limits, usage, flags }`
+  - `flags` should include:
+    - `isStructurallyFrozen`
+    - `canCreateContact`
+    - `canMutateContacts`
+    - `canCreateAutomation`
+    - `canMutateAutomations`
+    - `canUseSidekickChat`
+    - `canSendSidekickReply`
+- `assertBillingAllowed(userId, capability)`
+  - Throws a typed app error with a stable code and user-facing message when blocked.
+
+Define the freeze rule exactly like this:
+
+- `isStructurallyFrozen = contactsTotal > maxContactsTotal || automationsTotal > maxAutomations` for any non-null cap.
+- When `isStructurallyFrozen` is true:
+  - existing data remains readable
+  - all mutations are blocked
+  - background writes are skipped
+- Monthly quota exhaustion does not globally freeze the account.
+- Monthly quota exhaustion only disables that capability until the next month:
+  - chat prompt cap blocks Sidekick chat
+  - send cap blocks outbound Sidekick DM/comment sends
+  - new-contact cap blocks creation of new contacts only
+
+### 4. Add an immutable usage ledger for Sidekick chat prompts
+
+Add a new DB table in [schema.ts](C:/Users/USER/Desktop/code/pilot/packages/db/src/schema.ts), plus a migration, for example:
+
+- `billing_usage_event`
+  - `id`
+  - `userId` FK to `user`
+  - `kind` (v1 only needs `"sidekick_chat_prompt"`)
+  - `referenceId` nullable
+  - `createdAt defaultNow()`
+
+Reason: the current chat persistence in [chat-store.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/lib/chat-store.ts) deletes and recreates `chat_message` rows on every save, so `chat_message.createdAt` is not a reliable monthly quota signal.
+
+Usage rules:
+
+- Insert one `billing_usage_event(kind="sidekick_chat_prompt")` immediately after a chat request passes quota checks, before calling `streamText()`.
+- Do not try to backfill from `chat_message`.
+- Use this table only for chat prompts in v1.
+
+### 5. Enforce billing in all real mutation paths
+
+Add checks in the actual write paths, not just UI buttons.
+
+#### Automations
+
+Update [automations.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/actions/automations.ts):
+
+- `createAutomation`
+  - block when `isStructurallyFrozen`
+  - block when current automation count has reached `maxAutomations`
+- `updateAutomation`
+- `deleteAutomation`
+- `toggleAutomation`
+
+For the last three, block when `isStructurallyFrozen` so frozen accounts stay read-only.
+
+#### Contacts and contact mutations
+
+Update [contacts.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/actions/contacts.ts):
+
+- Block all contact mutation actions when `isStructurallyFrozen`
+  - `updateContactStage`
+  - `updateContactSentiment`
+  - `updateContactNotes`
+  - `updateContactHRNState`
+  - `updateContactFollowUpStatus`
+  - `updateContactAfterFollowUp`
+  - `addContactTagAction`
+  - `removeContactTagAction`
+  - `generateFollowUpMessage`
+- `syncInstagramContacts(fullSync?)`
+  - check `isStructurallyFrozen` before enqueueing sync
+  - if frozen, refuse the sync request up front
+
+#### Background contact sync
+
+Enforce in the real sync implementation at [sync.ts](C:/Users/USER/Desktop/code/pilot/packages/core/src/contacts/sync.ts), not only in the button action.
+
+Inside `storeContacts(...)`:
+
+- If `isStructurallyFrozen`, return without inserts/updates.
+- For each row:
+  - if the contact already exists, allow updates only when not frozen
+  - if the contact is new:
+    - block insert when `contactsTotal >= maxContactsTotal`
+    - block insert when `newContactsThisMonth >= maxNewContactsPerMonth`
+- Continue processing remaining contacts; do not crash the sync
+- Update `lastSyncedAt` normally only if the sync path itself ran successfully
+
+This ensures scheduled syncs and Inngest syncs respect limits too.
+
+#### Instagram webhook auto-replies
+
+Enforce in [instagram-webhook.ts](C:/Users/USER/Desktop/code/pilot/packages/core/src/workflows/instagram-webhook.ts).
+
+For direct-message flow:
+
+- Keep the duplicate-message guard first.
+- Then resolve billing status for `integration.userId`.
+- If `isStructurallyFrozen`, skip all writes and sends.
+- If the sender is a new contact and the user is at either contact cap, skip contact creation and skip sending.
+- If the sender is an existing contact and the account is not structurally frozen, existing-contact updates may continue.
+- Before sending any Sidekick reply:
+  - block when `maxSidekickSendsPerMonth` is reached
+- If send is blocked:
+  - do not call Instagram send APIs
+  - do not insert `sidekickActionLog`
+
+For comment automation flow:
+
+- Before any comment reply or DM-like send behavior, check `canSendSidekickReply`
+- If blocked, skip the reply and skip automation usage logging
+
+#### Sidekick chat API
+
+Update [route.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/app/api/chat/route.ts):
+
+- Resolve billing status at the top of `POST`.
+- If `isStructurallyFrozen`, reject the request before `streamText()`.
+- If `maxSidekickChatPromptsPerMonth` is reached, reject the request before `streamText()`.
+- If allowed, insert one `billing_usage_event` row before starting the model stream.
+
+Do not use `chat_message` for quota counting.
+
+### 6. Add a small UI billing-state surface
+
+Add a reusable server action or loader that returns `BillingStatus`, then use it to disable obvious mutation UI instead of only failing after click.
+
+Recommended minimal UI points:
+
+- Sidekick panel:
+  - disable prompt input when chat is blocked or account is structurally frozen
+  - show an upgrade message inline
+- Contacts:
+  - disable sync button when sync/new-contact creation is blocked
+  - keep tables readable
+- Automations:
+  - disable “new automation”
+  - optionally show a banner if the account is frozen
+- Upgrade page:
+  - show current plan from the centralized plan resolver
+
+Do not attempt to implement analytics gating now, because there is no analytics page in the current app route tree.
+
+### 7. Add a product setup document
+
+Create `docs/polar-product-setup.md` as a separate operator document.
+
+It should cover:
+
+- Create three recurring Polar products for `starter`, `growth`, `pro`
+- Configure them with no trial period
+- Record the monthly/yearly product IDs and slugs
+- Paste those IDs/slugs into `pricing.ts`
+- Confirm Better Auth checkout is using those slugs
+- Optional future step: configure Polar webhooks once you want local cache invalidation
+
+Because this implementation uses live Polar customer-state reads, webhook setup is not required to ship v1.
+
+## Public APIs / Interfaces / Types
+
+Add or standardize these interfaces so the implementation is consistent:
+
+- `type PlanId = "free" | "starter" | "growth" | "pro"`
+- `type BillingCapability = "contact:create" | "contact:mutate" | "automation:create" | "automation:mutate" | "sidekick:chat" | "sidekick:send"`
+- `type BillingLimits = { maxContactsTotal: number | null; maxNewContactsPerMonth: number | null; maxAutomations: number | null; maxSidekickSendsPerMonth: number | null; maxSidekickChatPromptsPerMonth: number | null }`
+- `type BillingUsage = { contactsTotal: number; newContactsThisMonth: number; automationsTotal: number; sidekickSendsThisMonth: number; sidekickChatPromptsThisMonth: number }`
+- `type BillingStatus = { planId: PlanId; limits: BillingLimits; usage: BillingUsage; flags: { isStructurallyFrozen: boolean; canCreateContact: boolean; canMutateContacts: boolean; canCreateAutomation: boolean; canMutateAutomations: boolean; canUseSidekickChat: boolean; canSendSidekickReply: boolean } }`
+
+Use typed error codes for blocked operations, for example:
+
+- `BILLING_STRUCTURALLY_FROZEN`
+- `BILLING_CONTACT_LIMIT_REACHED`
+- `BILLING_NEW_CONTACT_LIMIT_REACHED`
+- `BILLING_AUTOMATION_LIMIT_REACHED`
+- `BILLING_SIDEKICK_SEND_LIMIT_REACHED`
+- `BILLING_SIDEKICK_CHAT_LIMIT_REACHED`
+
+## Test Cases and Scenarios
+
+- No active Polar subscription resolves to `free`.
+- Each paid product ID resolves to the correct plan ID.
+- `pricing.ts` is the only place product IDs/slugs and limits are edited.
+- Free user at 99 contacts can add one more; at 100 cannot add new contacts.
+- User at `maxNewContactsPerMonth - 1` can create one new contact; the next new contact is blocked.
+- Existing contacts can still update when only the monthly new-contact cap is exhausted.
+- User over a downgraded structural cap becomes read-only:
+  - contacts list still loads
+  - automation list still loads
+  - all mutations fail
+  - scheduled sync and webhook writes are skipped
+- User at automation cap cannot create another automation.
+- User at sidekick send cap does not send DMs/comments and does not log a new `sidekickActionLog`.
+- User at chat cap gets rejected before model execution and before consuming another usage event.
+- Sidekick chat prompt usage is counted from `billing_usage_event`, not `chat_message`.
+- Sync job in [functions.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/lib/inngest/functions.ts) still completes gracefully when some contacts are skipped due to billing limits.
+- Upgrade UI shows four plans, and `free` is non-checkout.
+
+## Assumptions and Defaults Chosen
+
+- Users without an active Polar subscription are the `free` tier, not hard-paywalled.
+- This first pass only enforces numeric caps.
+- Monthly quotas reset on UTC calendar-month boundaries (00:00 UTC on the 1st).
+- Structural overage freezes the account read-only; monthly quota exhaustion only disables the specific exhausted capability.
+- `starter` and `growth` default to `maxSidekickSendsPerMonth = 0` because your pricing copy says “draft only, no sending.”
+- `generateFollowUpMessage` is blocked only when the account is structurally frozen in v1; it is not separately metered as a chat prompt yet.
+- Minor one-event overshoot under concurrent webhook traffic is acceptable in v1; no lock/reservation system is introduced.
+- No work is done for analytics/support/community/custom-webhook gating in this pass.
+
+## Research Basis
+
+- Polar recommends using Customer State as the single object for access provisioning, including active subscriptions and granted state: https://docs.polar.sh/integrate/customer-state
+- Polar exposes customer-state data via the customer-portal APIs used by Better Auth: https://docs.polar.sh/api-reference/customer-portal/customer-state
+- The installed Better Auth Polar plugin documents `authClient.customer.state()` and notes it includes active subscriptions, granted benefits, and active meters: [@polar-sh/better-auth README](C:/Users/USER/Desktop/code/pilot/apps/app/node_modules/@polar-sh/better-auth/README.md)
+- The same plugin documents the webhook plugin at `/polar/webhooks`; in this repo, because Better Auth is mounted at [route.ts](C:/Users/USER/Desktop/code/pilot/apps/app/src/app/api/auth/[...all]/route.ts), the effective path is inferred to be `/api/auth/polar/webhooks` if you add that plugin later.

--- a/packages/core/src/contacts/sync.ts
+++ b/packages/core/src/contacts/sync.ts
@@ -1,5 +1,5 @@
 import { contact, instagramIntegration, sidekickSetting } from "@pilot/db/schema";
-import { and, eq, inArray, lt } from "drizzle-orm";
+import { and, eq, gte, inArray, lt, sql } from "drizzle-orm";
 import {
   fetchConversationMessagesForSync,
   fetchConversationsForSync,
@@ -24,6 +24,8 @@ const MIN_MESSAGES_PER_CONTACT = 2;
 const DEFAULT_MESSAGE_LIMIT = 10;
 const BATCH_SIZE = 20;
 const REQUEST_DELAY_MS = 200;
+const EXISTING_CONTACT_WRITE_BATCH_SIZE = 10;
+const NEW_CONTACT_WRITE_BATCH_SIZE = 10;
 
 type IntegrationRecord = {
   id: string;
@@ -50,6 +52,90 @@ type BillingSyncSnapshot = {
     isStructurallyFrozen: boolean;
   };
 };
+
+function getStartOfUtcMonth(now: Date = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
+async function countContactsForUser(params: {
+  dbClient: any;
+  userId: string;
+  createdAfter?: Date;
+}) {
+  const conditions = [eq(contact.userId, params.userId)];
+
+  if (params.createdAfter) {
+    conditions.push(gte(contact.createdAt, params.createdAfter));
+  }
+
+  const [row] = await params.dbClient
+    .select({
+      count: sql<number>`count(*)::int`,
+    })
+    .from(contact)
+    .where(and(...conditions));
+
+  return row?.count ?? 0;
+}
+
+async function upsertContactRecord(params: {
+  dbClient: any;
+  row: {
+    id: string;
+    userId: string;
+    username: string | null | undefined;
+    lastMessage: string | null;
+    lastMessageAt: Date;
+    stage: AnalysisResult["stage"];
+    sentiment: AnalysisResult["sentiment"];
+    leadScore: number;
+    nextAction: string;
+    leadValue: number;
+    triggerMatched: boolean;
+    followupNeeded: boolean;
+    notes: string | null;
+    updatedAt: Date;
+    createdAt: Date;
+  };
+  fullSync: boolean;
+}) {
+  await params.dbClient
+    .insert(contact)
+    .values(params.row)
+    .onConflictDoUpdate({
+      target: contact.id,
+      set: params.fullSync
+        ? {
+            username: params.row.username,
+            lastMessage: params.row.lastMessage,
+            lastMessageAt: params.row.lastMessageAt,
+            stage: params.row.stage,
+            sentiment: params.row.sentiment,
+            leadScore: params.row.leadScore,
+            nextAction: params.row.nextAction,
+            leadValue: params.row.leadValue,
+            followupNeeded: params.row.followupNeeded,
+            updatedAt: new Date(),
+          }
+        : {
+            lastMessage: params.row.lastMessage,
+            lastMessageAt: params.row.lastMessageAt,
+            followupNeeded: params.row.followupNeeded,
+            updatedAt: new Date(),
+          },
+    });
+}
+
+async function processInChunks<T>(
+  items: T[],
+  chunkSize: number,
+  processor: (item: T) => Promise<void>,
+) {
+  for (let index = 0; index < items.length; index += chunkSize) {
+    const chunk = items.slice(index, index + chunkSize);
+    await Promise.all(chunk.map((item) => processor(item)));
+  }
+}
 
 async function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -288,14 +374,18 @@ async function storeContacts(params: {
     return [];
   }
 
-  const contacts: InstagramContact[] = [];
+  const storedContacts: InstagramContact[] = [];
   const now = new Date();
+  const monthStart = getStartOfUtcMonth(now);
   const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-  let contactsTotal = params.billing?.usage.contactsTotal ?? 0;
-  let newContactsThisMonth = params.billing?.usage.newContactsThisMonth ?? 0;
-
-  const hasReachedLimit = (current: number, limit: number | null | undefined) =>
-    limit !== null && limit !== undefined && current >= limit;
+  const existingContactItems: Array<{
+    contactPayload: InstagramContact;
+    row: Parameters<typeof upsertContactRecord>[0]["row"];
+  }> = [];
+  const newContactItems: Array<{
+    contactPayload: InstagramContact;
+    row: Parameters<typeof upsertContactRecord>[0]["row"];
+  }> = [];
 
   for (const item of params.contactsData) {
     const existingContact = params.existingContactsMap.get(item.participant.id);
@@ -333,51 +423,132 @@ async function storeContacts(params: {
       createdAt: existingContact?.createdAt || new Date(),
     };
 
-    if (!isExistingContact) {
-      const totalLimit = params.billing?.limits.maxContactsTotal;
-      const monthlyLimit = params.billing?.limits.maxNewContactsPerMonth;
-
-      if (
-        hasReachedLimit(contactsTotal, totalLimit) ||
-        hasReachedLimit(newContactsThisMonth, monthlyLimit)
-      ) {
-        continue;
-      }
-
-      contactsTotal += 1;
-      newContactsThisMonth += 1;
+    if (isExistingContact) {
+      existingContactItems.push({
+        contactPayload,
+        row,
+      });
+      continue;
     }
 
-    contacts.push(contactPayload);
-
-    await params.dbClient
-      .insert(contact)
-      .values(row)
-      .onConflictDoUpdate({
-        target: contact.id,
-        set: params.fullSync
-          ? {
-              username: row.username,
-              lastMessage: row.lastMessage,
-              lastMessageAt: row.lastMessageAt,
-              stage: row.stage,
-              sentiment: row.sentiment,
-              leadScore: row.leadScore,
-              nextAction: row.nextAction,
-              leadValue: row.leadValue,
-              followupNeeded: row.followupNeeded,
-              updatedAt: new Date(),
-            }
-          : {
-              lastMessage: row.lastMessage,
-              lastMessageAt: row.lastMessageAt,
-              followupNeeded: row.followupNeeded,
-              updatedAt: new Date(),
-            },
+    if (!params.billing) {
+      newContactItems.push({
+        contactPayload,
+        row,
       });
+      continue;
+    }
+
+    newContactItems.push({
+      contactPayload,
+      row,
+    });
   }
 
-  return contacts;
+  await processInChunks(
+    existingContactItems,
+    EXISTING_CONTACT_WRITE_BATCH_SIZE,
+    async (item) => {
+      await upsertContactRecord({
+        dbClient: params.dbClient,
+        row: item.row,
+        fullSync: params.fullSync,
+      });
+    },
+  );
+
+  storedContacts.push(...existingContactItems.map((item) => item.contactPayload));
+
+  if (!params.billing) {
+    await processInChunks(
+      newContactItems,
+      NEW_CONTACT_WRITE_BATCH_SIZE,
+      async (item) => {
+        await upsertContactRecord({
+          dbClient: params.dbClient,
+          row: item.row,
+          fullSync: params.fullSync,
+        });
+      },
+    );
+
+    storedContacts.push(...newContactItems.map((item) => item.contactPayload));
+    return storedContacts;
+  }
+
+  const billing = params.billing;
+
+  for (let index = 0; index < newContactItems.length; index += NEW_CONTACT_WRITE_BATCH_SIZE) {
+    const chunk = newContactItems.slice(index, index + NEW_CONTACT_WRITE_BATCH_SIZE);
+
+    const storedChunk = await params.dbClient.transaction(async (tx: any) => {
+      if (chunk.length === 0) {
+        return [] as InstagramContact[];
+      }
+
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext('contact_limit'), hashtext(${params.userId}))`,
+      );
+
+      const chunkIds = chunk.map((item) => item.row.id);
+      const existingRows = await tx.query.contact.findMany({
+        where: and(eq(contact.userId, params.userId), inArray(contact.id, chunkIds)),
+        columns: { id: true },
+      });
+
+      const existingIds = new Set(existingRows.map((row: { id: string }) => row.id));
+      const [contactsTotal, newContactsThisMonth] = await Promise.all([
+        countContactsForUser({
+          dbClient: tx,
+          userId: params.userId,
+        }),
+        countContactsForUser({
+          dbClient: tx,
+          userId: params.userId,
+          createdAfter: monthStart,
+        }),
+      ]);
+
+      const totalLimit = billing.limits.maxContactsTotal ?? null;
+      const monthlyLimit = billing.limits.maxNewContactsPerMonth ?? null;
+      let remainingTotal =
+        totalLimit === null ? Number.POSITIVE_INFINITY : Math.max(0, totalLimit - contactsTotal);
+      let remainingMonthly =
+        monthlyLimit === null
+          ? Number.POSITIVE_INFINITY
+          : Math.max(0, monthlyLimit - newContactsThisMonth);
+
+      const allowedItems = chunk.filter((item) => {
+        if (existingIds.has(item.row.id)) {
+          return true;
+        }
+
+        if (remainingTotal <= 0 || remainingMonthly <= 0) {
+          return false;
+        }
+
+        remainingTotal -= 1;
+        remainingMonthly -= 1;
+        return true;
+      });
+
+      await Promise.all(
+        allowedItems.map((item) =>
+          upsertContactRecord({
+            dbClient: tx,
+            row: item.row,
+            fullSync: params.fullSync,
+          }),
+        ),
+      );
+
+      return allowedItems.map((item) => item.contactPayload);
+    });
+
+    storedContacts.push(...storedChunk);
+  }
+
+  return storedContacts;
 }
 
 export async function fetchAndStoreInstagramContacts(params: {

--- a/packages/core/src/contacts/sync.ts
+++ b/packages/core/src/contacts/sync.ts
@@ -37,6 +37,20 @@ type IntegrationRecord = {
   syncIntervalHours: number | null;
 };
 
+type BillingSyncSnapshot = {
+  limits: {
+    maxContactsTotal: number | null;
+    maxNewContactsPerMonth: number | null;
+  };
+  usage: {
+    contactsTotal: number;
+    newContactsThisMonth: number;
+  };
+  flags: {
+    isStructurallyFrozen: boolean;
+  };
+};
+
 async function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -268,14 +282,24 @@ async function storeContacts(params: {
   userId: string;
   existingContactsMap: Map<string, typeof contact.$inferSelect>;
   fullSync: boolean;
+  billing?: BillingSyncSnapshot;
 }) {
+  if (params.billing?.flags.isStructurallyFrozen) {
+    return [];
+  }
+
   const contacts: InstagramContact[] = [];
-  const contactsToInsert = [];
   const now = new Date();
   const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  let contactsTotal = params.billing?.usage.contactsTotal ?? 0;
+  let newContactsThisMonth = params.billing?.usage.newContactsThisMonth ?? 0;
+
+  const hasReachedLimit = (current: number, limit: number | null | undefined) =>
+    limit !== null && limit !== undefined && current >= limit;
 
   for (const item of params.contactsData) {
     const existingContact = params.existingContactsMap.get(item.participant.id);
+    const isExistingContact = !!existingContact;
     const lastMessageTime = item.lastMessage?.created_time
       ? new Date(item.lastMessage.created_time)
       : new Date(item.timestamp);
@@ -283,16 +307,15 @@ async function storeContacts(params: {
     const needsFollowup =
       lastMessageTime < twentyFourHoursAgo && item.analysis.stage !== "ghosted";
 
-    contacts.push({
+    const contactPayload: InstagramContact = {
       id: item.participant.id,
       name: item.participant.username || "Unknown",
       lastMessage: item.lastMessage?.message || "",
       timestamp: item.timestamp,
       messages: item.messageTexts,
       ...item.analysis,
-    });
-
-    contactsToInsert.push({
+    };
+    const row = {
       id: item.participant.id,
       userId: params.userId,
       username: item.participant.username,
@@ -308,38 +331,51 @@ async function storeContacts(params: {
       notes: existingContact?.notes || null,
       updatedAt: new Date(),
       createdAt: existingContact?.createdAt || new Date(),
-    });
-  }
+    };
 
-  await Promise.all(
-    contactsToInsert.map((row) =>
-      params.dbClient
-        .insert(contact)
-        .values(row)
-        .onConflictDoUpdate({
-          target: contact.id,
-          set: params.fullSync
-            ? {
-                username: row.username,
-                lastMessage: row.lastMessage,
-                lastMessageAt: row.lastMessageAt,
-                stage: row.stage,
-                sentiment: row.sentiment,
-                leadScore: row.leadScore,
-                nextAction: row.nextAction,
-                leadValue: row.leadValue,
-                followupNeeded: row.followupNeeded,
-                updatedAt: new Date(),
-              }
-            : {
-                lastMessage: row.lastMessage,
-                lastMessageAt: row.lastMessageAt,
-                followupNeeded: row.followupNeeded,
-                updatedAt: new Date(),
-              },
-        }),
-    ),
-  );
+    if (!isExistingContact) {
+      const totalLimit = params.billing?.limits.maxContactsTotal;
+      const monthlyLimit = params.billing?.limits.maxNewContactsPerMonth;
+
+      if (
+        hasReachedLimit(contactsTotal, totalLimit) ||
+        hasReachedLimit(newContactsThisMonth, monthlyLimit)
+      ) {
+        continue;
+      }
+
+      contactsTotal += 1;
+      newContactsThisMonth += 1;
+    }
+
+    contacts.push(contactPayload);
+
+    await params.dbClient
+      .insert(contact)
+      .values(row)
+      .onConflictDoUpdate({
+        target: contact.id,
+        set: params.fullSync
+          ? {
+              username: row.username,
+              lastMessage: row.lastMessage,
+              lastMessageAt: row.lastMessageAt,
+              stage: row.stage,
+              sentiment: row.sentiment,
+              leadScore: row.leadScore,
+              nextAction: row.nextAction,
+              leadValue: row.leadValue,
+              followupNeeded: row.followupNeeded,
+              updatedAt: new Date(),
+            }
+          : {
+              lastMessage: row.lastMessage,
+              lastMessageAt: row.lastMessageAt,
+              followupNeeded: row.followupNeeded,
+              updatedAt: new Date(),
+            },
+      });
+  }
 
   return contacts;
 }
@@ -348,8 +384,13 @@ export async function fetchAndStoreInstagramContacts(params: {
   dbClient: any;
   userId: string;
   fullSync?: boolean;
+  billing?: BillingSyncSnapshot;
 }): Promise<InstagramContact[]> {
   try {
+    if (params.billing?.flags.isStructurallyFrozen) {
+      return [];
+    }
+
     const integration = await fetchInstagramIntegration(params.dbClient, params.userId);
     if (!integration) {
       return [];
@@ -431,6 +472,7 @@ export async function fetchAndStoreInstagramContacts(params: {
       userId: params.userId,
       existingContactsMap,
       fullSync,
+      billing: params.billing,
     });
 
     await params.dbClient

--- a/packages/core/src/workflows/instagram-webhook.ts
+++ b/packages/core/src/workflows/instagram-webhook.ts
@@ -152,7 +152,7 @@ async function processCommentChanges(params: {
   dbClient: any;
   changes: CommentChange[];
   igUserId: string | undefined;
-  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
+  resolveBillingStatus: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   for (const change of params.changes) {
     const value = change?.value;
@@ -178,11 +178,9 @@ async function processCommentChanges(params: {
       continue;
     }
 
-    if (params.resolveBillingStatus) {
-      const billingStatus = await params.resolveBillingStatus(integration.userId);
-      if (!billingStatus.flags.canSendSidekickReply) {
-        continue;
-      }
+    const billingStatus = await params.resolveBillingStatus(integration.userId);
+    if (!billingStatus.flags.canSendSidekickReply) {
+      continue;
     }
 
     const matchedAutomation = await checkTriggerMatch({
@@ -275,7 +273,7 @@ async function processDirectMessage(params: {
   senderId: string;
   messageText: string;
   webhookMid?: string | null;
-  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
+  resolveBillingStatus: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   const integration = await params.dbClient.query.instagramIntegration.findFirst({
     where: or(
@@ -327,11 +325,9 @@ async function processDirectMessage(params: {
     }
   }
 
-  const billingStatus = params.resolveBillingStatus
-    ? await params.resolveBillingStatus(integration.userId)
-    : null;
+  const billingStatus = await params.resolveBillingStatus(integration.userId);
 
-  if (billingStatus?.flags.isStructurallyFrozen) {
+  if (billingStatus.flags.isStructurallyFrozen) {
     return { status: "ok", frozen: true } as const;
   }
 
@@ -339,7 +335,7 @@ async function processDirectMessage(params: {
     where: and(eq(contact.userId, integration.userId), eq(contact.id, params.senderId)),
   });
 
-  if (!existingContact && billingStatus && !billingStatus.flags.canCreateContact) {
+  if (!existingContact && !billingStatus.flags.canCreateContact) {
     return { status: "ok", blocked: true } as const;
   }
 
@@ -425,7 +421,7 @@ async function processDirectMessage(params: {
     replyText = reply.text;
   }
 
-  if (billingStatus && !billingStatus.flags.canSendSidekickReply) {
+  if (!billingStatus.flags.canSendSidekickReply) {
     await upsertContactState({
       dbClient: params.dbClient,
       contactId: params.senderId,
@@ -542,7 +538,7 @@ export async function processInstagramWebhook(params: {
   dbClient: any;
   inngestClient: any;
   payload: InstagramWebhookPayload;
-  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
+  resolveBillingStatus: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   const entry = params.payload.entry?.[0];
   const changes = Array.isArray(entry?.changes)

--- a/packages/core/src/workflows/instagram-webhook.ts
+++ b/packages/core/src/workflows/instagram-webhook.ts
@@ -42,6 +42,14 @@ type InstagramWebhookPayload = {
   }>;
 };
 
+type BillingWebhookStatus = {
+  flags: {
+    isStructurallyFrozen: boolean;
+    canCreateContact: boolean;
+    canSendSidekickReply: boolean;
+  };
+};
+
 async function upsertContactState(params: {
   dbClient: any;
   contactId: string;
@@ -144,6 +152,7 @@ async function processCommentChanges(params: {
   dbClient: any;
   changes: CommentChange[];
   igUserId: string | undefined;
+  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   for (const change of params.changes) {
     const value = change?.value;
@@ -167,6 +176,13 @@ async function processCommentChanges(params: {
     });
     if (!integration) {
       continue;
+    }
+
+    if (params.resolveBillingStatus) {
+      const billingStatus = await params.resolveBillingStatus(integration.userId);
+      if (!billingStatus.flags.canSendSidekickReply) {
+        continue;
+      }
     }
 
     const matchedAutomation = await checkTriggerMatch({
@@ -259,6 +275,7 @@ async function processDirectMessage(params: {
   senderId: string;
   messageText: string;
   webhookMid?: string | null;
+  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   const integration = await params.dbClient.query.instagramIntegration.findFirst({
     where: or(
@@ -269,42 +286,6 @@ async function processDirectMessage(params: {
 
   if (!integration) {
     return { status: "ok" } as const;
-  }
-
-  const existingContact = await params.dbClient.query.contact.findFirst({
-    where: and(eq(contact.userId, integration.userId), eq(contact.id, params.senderId)),
-  });
-
-  if (existingContact?.requiresHumanResponse) {
-    const now = new Date();
-    await upsertContactState({
-      dbClient: params.dbClient,
-      contactId: params.senderId,
-      userId: integration.userId,
-      messageText: params.messageText,
-      stage: existingContact.stage ?? "new",
-      sentiment: existingContact.sentiment ?? "neutral",
-      leadScore: existingContact.leadScore ?? 50,
-      requiresHRN: true,
-      humanResponseSetAt: existingContact.humanResponseSetAt ?? now,
-    });
-    return { status: "ok", hrn: true } as const;
-  }
-
-  const hrnDecision = await classifyHumanResponseNeeded({ message: params.messageText });
-  if (hrnDecision.hrn) {
-    await upsertContactState({
-      dbClient: params.dbClient,
-      contactId: params.senderId,
-      userId: integration.userId,
-      messageText: params.messageText,
-      stage: existingContact?.stage ?? "new",
-      sentiment: existingContact?.sentiment ?? "neutral",
-      leadScore: existingContact?.leadScore ?? 50,
-      requiresHRN: true,
-      humanResponseSetAt: new Date(),
-    });
-    return { status: "ok", hrn: true } as const;
   }
 
   const threadId = `${integration.instagramUserId || params.igUserId}:${params.senderId}`;
@@ -344,6 +325,54 @@ async function processDirectMessage(params: {
     if (recent.length > 0) {
       return { status: "ok" } as const;
     }
+  }
+
+  const billingStatus = params.resolveBillingStatus
+    ? await params.resolveBillingStatus(integration.userId)
+    : null;
+
+  if (billingStatus?.flags.isStructurallyFrozen) {
+    return { status: "ok", frozen: true } as const;
+  }
+
+  const existingContact = await params.dbClient.query.contact.findFirst({
+    where: and(eq(contact.userId, integration.userId), eq(contact.id, params.senderId)),
+  });
+
+  if (!existingContact && billingStatus && !billingStatus.flags.canCreateContact) {
+    return { status: "ok", blocked: true } as const;
+  }
+
+  if (existingContact?.requiresHumanResponse) {
+    const now = new Date();
+    await upsertContactState({
+      dbClient: params.dbClient,
+      contactId: params.senderId,
+      userId: integration.userId,
+      messageText: params.messageText,
+      stage: existingContact.stage ?? "new",
+      sentiment: existingContact.sentiment ?? "neutral",
+      leadScore: existingContact.leadScore ?? 50,
+      requiresHRN: true,
+      humanResponseSetAt: existingContact.humanResponseSetAt ?? now,
+    });
+    return { status: "ok", hrn: true } as const;
+  }
+
+  const hrnDecision = await classifyHumanResponseNeeded({ message: params.messageText });
+  if (hrnDecision.hrn) {
+    await upsertContactState({
+      dbClient: params.dbClient,
+      contactId: params.senderId,
+      userId: integration.userId,
+      messageText: params.messageText,
+      stage: existingContact?.stage ?? "new",
+      sentiment: existingContact?.sentiment ?? "neutral",
+      leadScore: existingContact?.leadScore ?? 50,
+      requiresHRN: true,
+      humanResponseSetAt: new Date(),
+    });
+    return { status: "ok", hrn: true } as const;
   }
 
   const matchedAutomation = await checkTriggerMatch({
@@ -394,6 +423,21 @@ async function processDirectMessage(params: {
     }
 
     replyText = reply.text;
+  }
+
+  if (billingStatus && !billingStatus.flags.canSendSidekickReply) {
+    await upsertContactState({
+      dbClient: params.dbClient,
+      contactId: params.senderId,
+      userId: integration.userId,
+      messageText: params.messageText,
+      stage: existingContact?.stage ?? "new",
+      sentiment: existingContact?.sentiment ?? "neutral",
+      leadScore: existingContact?.leadScore ?? 50,
+      requiresHRN: existingContact?.requiresHumanResponse ?? false,
+      humanResponseSetAt: existingContact?.humanResponseSetAt ?? null,
+    });
+    return { status: "ok", sendBlocked: true } as const;
   }
 
   const sendResponse = await sendInstagramMessage({
@@ -498,6 +542,7 @@ export async function processInstagramWebhook(params: {
   dbClient: any;
   inngestClient: any;
   payload: InstagramWebhookPayload;
+  resolveBillingStatus?: (userId: string) => Promise<BillingWebhookStatus>;
 }) {
   const entry = params.payload.entry?.[0];
   const changes = Array.isArray(entry?.changes)
@@ -509,6 +554,7 @@ export async function processInstagramWebhook(params: {
       dbClient: params.dbClient,
       changes,
       igUserId: entry?.id,
+      resolveBillingStatus: params.resolveBillingStatus,
     });
     return { status: "ok" } as const;
   }
@@ -530,6 +576,7 @@ export async function processInstagramWebhook(params: {
       senderId,
       messageText,
       webhookMid: message?.message?.mid || null,
+      resolveBillingStatus: params.resolveBillingStatus,
     });
   } catch (error) {
     console.error("generateReply/send flow failed", error);

--- a/packages/db/drizzle/migrations/0029_cooing_butterfly.sql
+++ b/packages/db/drizzle/migrations/0029_cooing_butterfly.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "billing_usage_event" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"reference_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "billing_usage_event" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "billing_usage_event" ADD CONSTRAINT "billing_usage_event_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE POLICY "user_billing_usage_events_policy" ON "billing_usage_event" AS PERMISSIVE FOR ALL TO "authenticated" USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());

--- a/packages/db/drizzle/migrations/0030_worthless_songbird.sql
+++ b/packages/db/drizzle/migrations/0030_worthless_songbird.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "billing_usage_event" ADD CONSTRAINT "billing_usage_event_kind_check" CHECK ("billing_usage_event"."kind" = 'sidekick_chat_prompt');

--- a/packages/db/drizzle/migrations/meta/0029_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0029_snapshot.json
@@ -1,0 +1,1819 @@
+{
+  "id": "03ac5bf3-a528-42ec-bbf5-b58910f730a7",
+  "prevId": "20a1d6d4-9b41-4b12-b5e0-d05d02f33f98",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation": {
+      "name": "automation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_word": {
+          "name": "trigger_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_type": {
+          "name": "response_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_content": {
+          "name": "response_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trigger_scope": {
+          "name": "trigger_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dm'"
+        },
+        "hrn_enforced": {
+          "name": "hrn_enforced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment_reply_count": {
+          "name": "comment_reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment_reply_text": {
+          "name": "comment_reply_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_user_id_user_id_fk": {
+          "name": "automation_user_id_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automations_policy": {
+          "name": "user_automations_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_action_log": {
+      "name": "automation_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_word": {
+          "name": "trigger_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_action_log_user_id_user_id_fk": {
+          "name": "automation_action_log_user_id_user_id_fk",
+          "tableFrom": "automation_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_action_log_automation_id_automation_id_fk": {
+          "name": "automation_action_log_automation_id_automation_id_fk",
+          "tableFrom": "automation_action_log",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automation_action_logs_policy": {
+          "name": "user_automation_action_logs_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_post": {
+      "name": "automation_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_post_automation_id_automation_id_fk": {
+          "name": "automation_post_automation_id_automation_id_fk",
+          "tableFrom": "automation_post",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automation_posts_policy": {
+          "name": "user_automation_posts_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "automation_id IN (\n      SELECT id FROM automation WHERE user_id = auth.uid()\n    )",
+          "withCheck": "automation_id IN (\n      SELECT id FROM automation WHERE user_id = auth.uid()\n    )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_usage_event": {
+      "name": "billing_usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_usage_event_user_id_user_id_fk": {
+          "name": "billing_usage_event_user_id_user_id_fk",
+          "tableFrom": "billing_usage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_billing_usage_events_policy": {
+          "name": "user_billing_usage_events_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_chat_messages_policy": {
+          "name": "user_chat_messages_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "session_id IN (\n      SELECT id FROM chat_session WHERE user_id = auth.uid()\n    )",
+          "withCheck": "session_id IN (\n      SELECT id FROM chat_session WHERE user_id = auth.uid()\n    )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_session_user_id_user_id_fk": {
+          "name": "chat_session_user_id_user_id_fk",
+          "tableFrom": "chat_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_chat_sessions_policy": {
+          "name": "user_chat_sessions_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'new'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "lead_score": {
+          "name": "lead_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_value": {
+          "name": "lead_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_matched": {
+          "name": "trigger_matched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "followup_needed": {
+          "name": "followup_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "followup_message": {
+          "name": "followup_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_human_response": {
+          "name": "requires_human_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "human_response_set_at": {
+          "name": "human_response_set_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_user_id_user_id_fk": {
+          "name": "contact_user_id_user_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_contacts_policy": {
+          "name": "user_contacts_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_tag": {
+      "name": "contact_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_tag_user_id_user_id_fk": {
+          "name": "contact_tag_user_id_user_id_fk",
+          "tableFrom": "contact_tag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_tag_contact_id_contact_id_fk": {
+          "name": "contact_tag_contact_id_contact_id_fk",
+          "tableFrom": "contact_tag",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_contact_tags_policy": {
+          "name": "user_contact_tags_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_integration": {
+      "name": "instagram_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instagram_user_id": {
+          "name": "instagram_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_scoped_user_id": {
+          "name": "app_scoped_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval_hours": {
+          "name": "sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instagram_integration_user_id_user_id_fk": {
+          "name": "instagram_integration_user_id_user_id_fk",
+          "tableFrom": "instagram_integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_instagram_integration_policy": {
+          "name": "user_instagram_integration_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidekick_action_log": {
+      "name": "sidekick_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_mid": {
+          "name": "webhook_mid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sidekick_action_log_user_id_user_id_fk": {
+          "name": "sidekick_action_log_user_id_user_id_fk",
+          "tableFrom": "sidekick_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_sidekick_action_logs_policy": {
+          "name": "user_sidekick_action_logs_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidekick_setting": {
+      "name": "sidekick_setting",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'You are a friendly, professional assistant focused on qualifying leads and helping with business inquiries.'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sidekick_setting_user_id_user_id_fk": {
+          "name": "sidekick_setting_user_id_user_id_fk",
+          "tableFrom": "sidekick_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_sidekick_settings_policy": {
+          "name": "user_sidekick_settings_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_use_case": {
+          "name": "other_use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leads_per_month": {
+          "name": "leads_per_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_platforms": {
+          "name": "active_platforms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_platform": {
+          "name": "other_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_business_type": {
+          "name": "other_business_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pilot_goal": {
+          "name": "pilot_goal",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_tracking": {
+          "name": "current_tracking",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_tracking": {
+          "name": "other_tracking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_offering": {
+          "name": "main_offering",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sidekick_onboarding_complete": {
+          "name": "sidekick_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_faq": {
+      "name": "user_faq",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_faq_user_id_user_id_fk": {
+          "name": "user_faq_user_id_user_id_fk",
+          "tableFrom": "user_faq",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_faq_policy": {
+          "name": "user_faq_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_offer": {
+      "name": "user_offer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_offer_user_id_user_id_fk": {
+          "name": "user_offer_user_id_user_id_fk",
+          "tableFrom": "user_offer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_offers_policy": {
+          "name": "user_offers_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_offer_link": {
+      "name": "user_offer_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_offer_link_user_id_user_id_fk": {
+          "name": "user_offer_link_user_id_user_id_fk",
+          "tableFrom": "user_offer_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_offer_links_policy": {
+          "name": "user_offer_links_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tone_profile": {
+      "name": "user_tone_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone_type": {
+          "name": "tone_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_text": {
+          "name": "sample_text",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_files": {
+          "name": "sample_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trained_embedding_id": {
+          "name": "trained_embedding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tone_profile_user_id_user_id_fk": {
+          "name": "user_tone_profile_user_id_user_id_fk",
+          "tableFrom": "user_tone_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_tone_profile_policy": {
+          "name": "user_tone_profile_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "waitlist_policy": {
+          "name": "waitlist_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/0030_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0030_snapshot.json
@@ -1,0 +1,1824 @@
+{
+  "id": "9850ea54-d03f-439c-ab0f-fe4abd911f38",
+  "prevId": "03ac5bf3-a528-42ec-bbf5-b58910f730a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation": {
+      "name": "automation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_word": {
+          "name": "trigger_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_type": {
+          "name": "response_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_content": {
+          "name": "response_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trigger_scope": {
+          "name": "trigger_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dm'"
+        },
+        "hrn_enforced": {
+          "name": "hrn_enforced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment_reply_count": {
+          "name": "comment_reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment_reply_text": {
+          "name": "comment_reply_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_user_id_user_id_fk": {
+          "name": "automation_user_id_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automations_policy": {
+          "name": "user_automations_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_action_log": {
+      "name": "automation_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_word": {
+          "name": "trigger_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_action_log_user_id_user_id_fk": {
+          "name": "automation_action_log_user_id_user_id_fk",
+          "tableFrom": "automation_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_action_log_automation_id_automation_id_fk": {
+          "name": "automation_action_log_automation_id_automation_id_fk",
+          "tableFrom": "automation_action_log",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automation_action_logs_policy": {
+          "name": "user_automation_action_logs_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_post": {
+      "name": "automation_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_post_automation_id_automation_id_fk": {
+          "name": "automation_post_automation_id_automation_id_fk",
+          "tableFrom": "automation_post",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_automation_posts_policy": {
+          "name": "user_automation_posts_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "automation_id IN (\n      SELECT id FROM automation WHERE user_id = auth.uid()\n    )",
+          "withCheck": "automation_id IN (\n      SELECT id FROM automation WHERE user_id = auth.uid()\n    )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_usage_event": {
+      "name": "billing_usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_usage_event_user_id_user_id_fk": {
+          "name": "billing_usage_event_user_id_user_id_fk",
+          "tableFrom": "billing_usage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_billing_usage_events_policy": {
+          "name": "user_billing_usage_events_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {
+        "billing_usage_event_kind_check": {
+          "name": "billing_usage_event_kind_check",
+          "value": "\"billing_usage_event\".\"kind\" = 'sidekick_chat_prompt'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_chat_messages_policy": {
+          "name": "user_chat_messages_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "session_id IN (\n      SELECT id FROM chat_session WHERE user_id = auth.uid()\n    )",
+          "withCheck": "session_id IN (\n      SELECT id FROM chat_session WHERE user_id = auth.uid()\n    )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_session_user_id_user_id_fk": {
+          "name": "chat_session_user_id_user_id_fk",
+          "tableFrom": "chat_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_chat_sessions_policy": {
+          "name": "user_chat_sessions_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'new'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "lead_score": {
+          "name": "lead_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_value": {
+          "name": "lead_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_matched": {
+          "name": "trigger_matched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "followup_needed": {
+          "name": "followup_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "followup_message": {
+          "name": "followup_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_human_response": {
+          "name": "requires_human_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "human_response_set_at": {
+          "name": "human_response_set_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_user_id_user_id_fk": {
+          "name": "contact_user_id_user_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_contacts_policy": {
+          "name": "user_contacts_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_tag": {
+      "name": "contact_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_tag_user_id_user_id_fk": {
+          "name": "contact_tag_user_id_user_id_fk",
+          "tableFrom": "contact_tag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_tag_contact_id_contact_id_fk": {
+          "name": "contact_tag_contact_id_contact_id_fk",
+          "tableFrom": "contact_tag",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_contact_tags_policy": {
+          "name": "user_contact_tags_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_integration": {
+      "name": "instagram_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instagram_user_id": {
+          "name": "instagram_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_scoped_user_id": {
+          "name": "app_scoped_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval_hours": {
+          "name": "sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instagram_integration_user_id_user_id_fk": {
+          "name": "instagram_integration_user_id_user_id_fk",
+          "tableFrom": "instagram_integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_instagram_integration_policy": {
+          "name": "user_instagram_integration_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidekick_action_log": {
+      "name": "sidekick_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_mid": {
+          "name": "webhook_mid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sidekick_action_log_user_id_user_id_fk": {
+          "name": "sidekick_action_log_user_id_user_id_fk",
+          "tableFrom": "sidekick_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_sidekick_action_logs_policy": {
+          "name": "user_sidekick_action_logs_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidekick_setting": {
+      "name": "sidekick_setting",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'You are a friendly, professional assistant focused on qualifying leads and helping with business inquiries.'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sidekick_setting_user_id_user_id_fk": {
+          "name": "sidekick_setting_user_id_user_id_fk",
+          "tableFrom": "sidekick_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_sidekick_settings_policy": {
+          "name": "user_sidekick_settings_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_use_case": {
+          "name": "other_use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leads_per_month": {
+          "name": "leads_per_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_platforms": {
+          "name": "active_platforms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_platform": {
+          "name": "other_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_business_type": {
+          "name": "other_business_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pilot_goal": {
+          "name": "pilot_goal",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_tracking": {
+          "name": "current_tracking",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_tracking": {
+          "name": "other_tracking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_offering": {
+          "name": "main_offering",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sidekick_onboarding_complete": {
+          "name": "sidekick_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_faq": {
+      "name": "user_faq",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_faq_user_id_user_id_fk": {
+          "name": "user_faq_user_id_user_id_fk",
+          "tableFrom": "user_faq",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_faq_policy": {
+          "name": "user_faq_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_offer": {
+      "name": "user_offer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_offer_user_id_user_id_fk": {
+          "name": "user_offer_user_id_user_id_fk",
+          "tableFrom": "user_offer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_offers_policy": {
+          "name": "user_offers_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_offer_link": {
+      "name": "user_offer_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_offer_link_user_id_user_id_fk": {
+          "name": "user_offer_link_user_id_user_id_fk",
+          "tableFrom": "user_offer_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_offer_links_policy": {
+          "name": "user_offer_links_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tone_profile": {
+      "name": "user_tone_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone_type": {
+          "name": "tone_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_text": {
+          "name": "sample_text",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_files": {
+          "name": "sample_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trained_embedding_id": {
+          "name": "trained_embedding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tone_profile_user_id_user_id_fk": {
+          "name": "user_tone_profile_user_id_user_id_fk",
+          "tableFrom": "user_tone_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_tone_profile_policy": {
+          "name": "user_tone_profile_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "user_id = auth.uid()",
+          "withCheck": "user_id = auth.uid()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "waitlist_policy": {
+          "name": "waitlist_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1772544377568,
       "tag": "0029_cooing_butterfly",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1772641480497,
+      "tag": "0030_worthless_songbird",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1771679119815,
       "tag": "0028_unusual_mariko_yashida",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1772544377568,
+      "tag": "0029_cooing_butterfly",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6,6 +6,7 @@ import {
   integer,
   unique,
   pgPolicy,
+  check,
 } from "drizzle-orm/pg-core";
 import { authenticatedRole } from "drizzle-orm/neon";
 import { sql } from "drizzle-orm";
@@ -341,7 +342,11 @@ export const billingUsageEvent = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (_table) => [
+  (table) => [
+    check(
+      "billing_usage_event_kind_check",
+      sql`${table.kind} = 'sidekick_chat_prompt'`,
+    ),
     pgPolicy("user_billing_usage_events_policy", {
       for: "all",
       to: authenticatedRole,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -327,6 +327,30 @@ export const sidekickActionLog = pgTable(
   ],
 );
 
+export const billingUsageEvent = pgTable(
+  "billing_usage_event",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    kind: text("kind")
+      .notNull()
+      .$type<"sidekick_chat_prompt">(),
+    referenceId: text("reference_id"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (_table) => [
+    pgPolicy("user_billing_usage_events_policy", {
+      for: "all",
+      to: authenticatedRole,
+      using: sql`user_id = auth.uid()`,
+      withCheck: sql`user_id = auth.uid()`,
+    }),
+  ],
+);
+
 export const chatSession = pgTable(
   "chat_session",
   {

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -19,6 +19,7 @@
     "hooks": "@/hooks"
   },
   "registries": {
-    "@efferd": "https://efferd.com/r/{name}.json"
+    "@efferd": "https://efferd.com/r/{name}.json",
+    "@tailark": "https://tailark.com/r/{name}.json"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         version: 0.34.17
       '@sentry/nextjs':
         specifier: ^10.39.0
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.101.2(esbuild@0.25.12))
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.101.2)
       '@t3-oss/env-nextjs':
         specifier: ^0.13.10
         version: 0.13.10(typescript@5.9.3)(zod@4.3.6)
@@ -93,10 +93,10 @@ importers:
         version: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights':
         specifier: ^1.3.1
-        version: 1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^5.0.137
         version: 5.0.137(zod@4.3.6)
@@ -226,10 +226,10 @@ importers:
         version: link:../../packages/ui
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -272,7 +272,7 @@ importers:
         version: 9.39.3(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -281,10 +281,10 @@ importers:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.56.0
-        version: 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.56.0
-        version: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
 
   packages/core:
     dependencies:
@@ -9801,7 +9801,7 @@ snapshots:
 
   '@sentry/core@10.39.0': {}
 
-  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.101.2(esbuild@0.25.12))':
+  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.101.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -9813,7 +9813,7 @@ snapshots:
       '@sentry/opentelemetry': 10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
       '@sentry/react': 10.39.0(react@19.2.4)
       '@sentry/vercel-edge': 10.39.0
-      '@sentry/webpack-plugin': 4.9.1(webpack@5.101.2(esbuild@0.25.12))
+      '@sentry/webpack-plugin': 4.9.1(webpack@5.101.2)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.58.0
       stacktrace-parser: 0.1.11
@@ -9904,12 +9904,12 @@ snapshots:
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.39.0
 
-  '@sentry/webpack-plugin@4.9.1(webpack@5.101.2(esbuild@0.25.12))':
+  '@sentry/webpack-plugin@4.9.1(webpack@5.101.2)':
     dependencies:
       '@sentry/bundler-plugin-core': 4.9.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.2(esbuild@0.25.12)
+      webpack: 5.101.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10325,6 +10325,22 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.56.0
+      eslint: 9.39.3(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -10341,6 +10357,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.56.0
+      debug: 4.4.3
+      eslint: 9.39.3(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
@@ -10350,6 +10378,15 @@ snapshots:
       debug: 4.4.3
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.56.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.56.0
+      debug: 4.4.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10367,9 +10404,25 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
 
+  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
   '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 9.39.3(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -10385,6 +10438,21 @@ snapshots:
 
   '@typescript-eslint/types@8.56.0': {}
 
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/visitor-keys': 8.56.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.56.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.56.0(typescript@5.9.3)
@@ -10397,6 +10465,17 @@ snapshots:
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.2)
+      eslint: 9.39.3(jiti@2.6.1)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10477,14 +10556,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -11561,28 +11640,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.3(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
-  eslint-config-next@16.1.6(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.1.6
-      eslint: 9.39.3(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.3(jiti@2.6.1))
@@ -11604,7 +11663,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11619,14 +11678,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11641,7 +11700,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11654,33 +11713,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.3(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14272,16 +14304,14 @@ snapshots:
 
   temporal-spec@0.2.4: {}
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.101.2(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.16(webpack@5.101.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.101.2(esbuild@0.25.12)
-    optionalDependencies:
-      esbuild: 0.25.12
+      webpack: 5.101.2
 
   terser@5.46.0:
     dependencies:
@@ -14314,6 +14344,10 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
+
+  ts-api-utils@2.4.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -14637,7 +14671,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.101.2(esbuild@0.25.12):
+  webpack@5.101.2:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -14661,7 +14695,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.101.2(esbuild@0.25.12))
+      terser-webpack-plugin: 5.3.16(webpack@5.101.2)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements comprehensive billing tier enforcement using Polar for subscription management. The implementation adds a well-structured billing enforcement layer across all mutation paths including contacts, automations, and Sidekick chat.

**Key changes:**
- Added billing enforcement modules (`enforce.ts`, `plan.ts`, `usage.ts`, `types.ts`) with proper error handling
- Refactored pricing catalog to be the single source of truth for tier configuration and Polar product mappings
- Added `billing_usage_event` table to track Sidekick chat prompt usage with proper RLS policies
- Enforced billing limits in all server actions (contacts, automations), API routes (chat, webhooks), and background jobs (Inngest sync)
- Implemented "structural freeze" logic: accounts over total contact/automation caps become read-only
- Monthly quota exhaustion only disables specific capabilities (chat prompts, sends, new contacts)
- UI properly disables actions and shows informative messages when limits are reached
- Background processes (webhooks, syncs) gracefully skip operations when billing limits prevent them

**Implementation quality:**
- Follows the documented plan in `docs/polar-tier-enforcement.md` very closely
- Proper error handling with typed `BillingLimitError` exceptions
- Consistent enforcement across all code paths (UI, API, webhooks, background jobs)
- Defaults to free tier on Polar API failures, preventing service disruption
- Uses UTC month boundaries for consistent monthly quota tracking

**Note:** Polar product IDs in `pricing.ts` are currently `null` with TODO markers - checkout will not work until these are configured in Polar and updated in the code.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after configuring Polar product IDs for paid tiers
- The implementation is solid with proper error handling, consistent enforcement across all paths, and comprehensive coverage. Score is 4 instead of 5 because Polar product IDs need to be configured before checkout functionality works, and the feature should be tested end-to-end with actual Polar integration before full deployment.
- `apps/app/src/lib/constants/pricing.ts` needs Polar product IDs configured before checkout will work

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/app/src/lib/billing/enforce.ts | Core billing enforcement logic with proper error handling and flag computation |
| apps/app/src/lib/constants/pricing.ts | Pricing plans defined but Polar product IDs are null (marked with TODOs) |
| apps/app/src/actions/contacts.ts | Contact actions properly enforce billing limits with error handling |
| apps/app/src/actions/automations.ts | Automation CRUD operations enforce billing limits correctly |
| apps/app/src/app/api/chat/route.ts | Chat API enforces limits before streaming and records usage events |
| packages/core/src/workflows/instagram-webhook.ts | Webhook processing respects billing limits before creating contacts or sending replies |
| packages/core/src/contacts/sync.ts | Contact sync enforces limits during batch operations, gracefully skips when at capacity |
| packages/db/src/schema.ts | Added `billing_usage_event` table with proper constraints and RLS policies |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Action/Request] --> B{Authenticated?}
    B -->|No| C[Reject: 401]
    B -->|Yes| D[Get Current Plan from Polar]
    D --> E[Get Current Usage from DB]
    E --> F[Calculate Billing Status]
    F --> G{Structurally Frozen?}
    G -->|Yes| H[Reject: Workspace Frozen]
    G -->|No| I{Check Capability}
    I -->|contact:create| J{At Contact Limits?}
    I -->|automation:create| K{At Automation Limit?}
    I -->|sidekick:chat| L{At Chat Prompt Limit?}
    I -->|sidekick:send| M{At Send Limit?}
    J -->|Yes| N[Reject: Contact Limit]
    J -->|No| O[Allow & Execute]
    K -->|Yes| P[Reject: Automation Limit]
    K -->|No| O
    L -->|Yes| Q[Reject: Chat Limit]
    L -->|No| R[Record Usage Event]
    R --> O
    M -->|Yes| S[Reject: Send Limit]
    M -->|No| O
    O --> T[Success Response]
    
    style G fill:#ffcccc
    style J fill:#ffffcc
    style K fill:#ffffcc
    style L fill:#ffffcc
    style M fill:#ffffcc
    style O fill:#ccffcc
```

<sub>Last reviewed commit: f79cdf4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->