### PR TITLE
new onboarding flow

### DIFF
--- a/apps/app/src/actions/onboarding.ts
+++ b/apps/app/src/actions/onboarding.ts
@@ -52,7 +52,7 @@ function getLeadParticipant(
 }
 
 function isBusinessMessage(message: InstagramMessage, businessUsername: string) {
-  return message.from.username === businessUsername;
+  return message.from?.username === businessUsername;
 }
 
 function getTextMessages(messages: InstagramMessage[]) {

--- a/apps/app/src/actions/onboarding.ts
+++ b/apps/app/src/actions/onboarding.ts
@@ -51,21 +51,62 @@ function getLeadParticipant(
   });
 }
 
-function formatPreviewMessages(params: {
-  businessUsername: string;
-  leadName: string;
-  messages: InstagramMessage[];
-}): OnboardingPreviewMessage[] {
-  return params.messages
+function isBusinessMessage(message: InstagramMessage, businessUsername: string) {
+  return message.from.username === businessUsername;
+}
+
+function getTextMessages(messages: InstagramMessage[]) {
+  return messages
     .filter(
       (message) =>
         typeof message.message === "string" &&
         message.message.trim().length > 0,
     )
-    .slice(0, 6)
+    .sort((left, right) => {
+      const leftTime = new Date(left.created_time).getTime();
+      const rightTime = new Date(right.created_time).getTime();
+
+      if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+        return 0;
+      }
+
+      return leftTime - rightTime;
+    });
+}
+
+function buildPreviewMessages(params: {
+  businessUsername: string;
+  leadName: string;
+  messages: InstagramMessage[];
+}): OnboardingPreviewMessage[] {
+  const textMessages = getTextMessages(params.messages);
+
+  const lastIncomingIndex = [...textMessages]
+    .map((message, index) => ({ message, index }))
     .reverse()
+    .find(
+      ({ message }) => !isBusinessMessage(message, params.businessUsername),
+    )?.index;
+
+  if (lastIncomingIndex === undefined) {
+    return [];
+  }
+
+  const hasBusinessReplyBeforeLatestIncoming = textMessages
+    .slice(0, lastIncomingIndex)
+    .some((message) => isBusinessMessage(message, params.businessUsername));
+
+  if (!hasBusinessReplyBeforeLatestIncoming) {
+    return [];
+  }
+
+  return textMessages
+    .slice(Math.max(0, lastIncomingIndex - 5), lastIncomingIndex + 1)
     .map((message) => {
-      const isBusinessReply = message.from.username === params.businessUsername;
+      const isBusinessReply = isBusinessMessage(
+        message,
+        params.businessUsername,
+      );
 
       return {
         direction: isBusinessReply ? "outgoing" : "incoming",
@@ -127,6 +168,45 @@ async function buildReplyPreview(params: {
     console.error("Error generating onboarding preview reply:", error);
     return params.fallbackReply;
   }
+}
+
+function selectPreviewConversation(
+  conversations: InstagramConversation[],
+  integration: {
+    appScopedUserId: string | null;
+    instagramUserId: string;
+    username: string;
+  },
+  userName?: string | null,
+) {
+  for (const conversation of conversations) {
+    if (!Array.isArray(conversation.messages?.data)) {
+      continue;
+    }
+
+    const leadParticipant = getLeadParticipant(conversation, integration) ?? {
+      id: "lead",
+      username: userName ? `${userName}'s lead` : "Lead",
+    };
+
+    const previewMessages = buildPreviewMessages({
+      businessUsername: integration.username,
+      leadName: leadParticipant.username,
+      messages: conversation.messages.data,
+    });
+
+    if (previewMessages.length === 0) {
+      continue;
+    }
+
+    return {
+      conversation,
+      leadParticipant,
+      previewMessages,
+    };
+  }
+
+  return null;
 }
 
 export async function getUserData() {
@@ -298,18 +378,17 @@ export async function prepareInstagramPreview() {
       .filter((conversation) => Array.isArray(conversation.messages?.data))
       .slice(0, 12);
 
-    const previewConversation = recentConversations.find((conversation) => {
-      return (
-        Array.isArray(conversation.messages?.data) &&
-        conversation.messages.data.some(
-          (message) =>
-            typeof message.message === "string" &&
-            message.message.trim().length > 0,
-        )
-      );
-    });
+    const previewSelection = selectPreviewConversation(
+      recentConversations,
+      {
+        appScopedUserId: integration.appScopedUserId,
+        instagramUserId: integration.instagramUserId,
+        username: integration.username,
+      },
+      userData?.name,
+    );
 
-    if (!previewConversation?.messages?.data?.length) {
+    if (!previewSelection) {
       return {
         success: true,
         connected: true,
@@ -317,28 +396,7 @@ export async function prepareInstagramPreview() {
       } as const;
     }
 
-    const leadParticipant = getLeadParticipant(previewConversation, {
-      appScopedUserId: integration.appScopedUserId,
-      instagramUserId: integration.instagramUserId,
-      username: integration.username,
-    }) ?? {
-      id: "lead",
-      username: userData?.name ? `${userData.name}'s lead` : "Lead",
-    };
-
-    const previewMessages = formatPreviewMessages({
-      businessUsername: integration.username,
-      leadName: leadParticipant.username,
-      messages: previewConversation.messages.data,
-    });
-
-    if (previewMessages.length === 0) {
-      return {
-        success: true,
-        connected: true,
-        data: fallback,
-      } as const;
-    }
+    const { leadParticipant, previewMessages } = previewSelection;
 
     const conversationContext = buildConversationContext(previewMessages);
     const fallbackReply =

--- a/apps/app/src/actions/onboarding.ts
+++ b/apps/app/src/actions/onboarding.ts
@@ -2,10 +2,132 @@
 
 import { auth } from "@/lib/auth";
 import { getRLSDb } from "@/lib/auth-utils";
-import { user } from "@pilot/db/schema";
+import { sanitizeText } from "@/lib/utils";
+import { getInstagramIntegration } from "@/actions/instagram";
+import { instagramIntegration, user } from "@pilot/db/schema";
+import { generateText, geminiModel } from "@pilot/core/ai/model";
+import { getPersonalizedAutoReplyPrompt } from "@pilot/core/sidekick/personalization";
+import { fetchConversationsForSync } from "@pilot/instagram";
+import type {
+  InstagramConversation,
+  InstagramMessage,
+  InstagramParticipant,
+} from "@pilot/types/instagram";
 import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+
+type OnboardingPreviewMessage = {
+  direction: "incoming" | "outgoing";
+  sender: string;
+  text: string;
+  timestamp: string;
+};
+
+type OnboardingPreviewData = {
+  accountUsername: string;
+  conversationCount: number;
+  previewMessages: OnboardingPreviewMessage[];
+  previewTarget: string;
+  pulledDmCount: number;
+  replyPreview: string;
+  source: "live" | "starter";
+};
+
+function getLeadParticipant(
+  conversation: InstagramConversation,
+  integration: {
+    appScopedUserId: string | null;
+    instagramUserId: string;
+    username: string;
+  },
+): InstagramParticipant | undefined {
+  return conversation.participants.data.find((participant) => {
+    return (
+      participant.id !== integration.instagramUserId &&
+      participant.id !== integration.appScopedUserId &&
+      participant.username !== integration.username
+    );
+  });
+}
+
+function formatPreviewMessages(params: {
+  businessUsername: string;
+  leadName: string;
+  messages: InstagramMessage[];
+}): OnboardingPreviewMessage[] {
+  return params.messages
+    .filter(
+      (message) =>
+        typeof message.message === "string" &&
+        message.message.trim().length > 0,
+    )
+    .slice(0, 6)
+    .reverse()
+    .map((message) => {
+      const isBusinessReply = message.from.username === params.businessUsername;
+
+      return {
+        direction: isBusinessReply ? "outgoing" : "incoming",
+        sender: isBusinessReply ? "You" : params.leadName,
+        text: sanitizeText(message.message).slice(0, 280),
+        timestamp: message.created_time,
+      };
+    });
+}
+
+function buildConversationContext(messages: OnboardingPreviewMessage[]) {
+  return messages
+    .map((message) => `${message.sender}: ${message.text}`)
+    .join("\n");
+}
+
+function buildFallbackPreview(accountUsername: string): OnboardingPreviewData {
+  return {
+    accountUsername,
+    conversationCount: 0,
+    previewMessages: [
+      {
+        direction: "incoming",
+        sender: "Lead",
+        text: "Hey, is this still available? I'd love the details.",
+        timestamp: new Date().toISOString(),
+      },
+    ],
+    previewTarget: "Lead",
+    pulledDmCount: 0,
+    replyPreview:
+      "Yep, it is. I can send the details here and point you to the best next step based on what you're looking for.",
+    source: "starter",
+  };
+}
+
+async function buildReplyPreview(params: {
+  conversationContext: string;
+  fallbackReply: string;
+  userId: string;
+}) {
+  try {
+    const db = await getRLSDb();
+    const personalized = await getPersonalizedAutoReplyPrompt(
+      db,
+      params.conversationContext,
+      params.userId,
+    );
+    const aiResult = await generateText({
+      model: geminiModel,
+      system: personalized.system,
+      prompt: personalized.main,
+      temperature: 0.4,
+    });
+
+    const reply = sanitizeText(aiResult.text).slice(0, 280);
+    return reply || params.fallbackReply;
+  } catch (error) {
+    console.error("Error generating onboarding preview reply:", error);
+    return params.fallbackReply;
+  }
+}
 
 export async function getUserData() {
   const session = await auth.api.getSession({
@@ -32,7 +154,7 @@ export async function getUserData() {
 }
 
 export async function updateOnboardingStep(
-  formData: Record<string, string | string[]>
+  formData: Record<string, string | string[]>,
 ) {
   const session = await auth.api.getSession({
     headers: await headers(),
@@ -100,5 +222,168 @@ export async function checkOnboardingStatus() {
       onboarding_complete: false,
       error: "Failed to check onboarding status",
     };
+  }
+}
+
+export async function getInstagramOnboardingState() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session || !session.user) {
+    redirect("/sign-in");
+  }
+
+  try {
+    const integration = await getInstagramIntegration();
+
+    if (!integration.connected) {
+      return { connected: false } as const;
+    }
+
+    return {
+      connected: true,
+      username: integration.username,
+    } as const;
+  } catch (error) {
+    console.error("Error checking Instagram onboarding state:", error);
+    return {
+      connected: false,
+      error: "Failed to check Instagram connection",
+    } as const;
+  }
+}
+
+export async function prepareInstagramPreview() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session || !session.user) {
+    redirect("/sign-in");
+  }
+
+  try {
+    const db = await getRLSDb();
+    const [integration, userData] = await Promise.all([
+      db.query.instagramIntegration.findFirst({
+        where: eq(instagramIntegration.userId, session.user.id),
+      }),
+      db
+        .select({ name: user.name })
+        .from(user)
+        .where(eq(user.id, session.user.id))
+        .then((rows) => rows[0]),
+    ]);
+
+    if (!integration) {
+      return {
+        success: false,
+        connected: false,
+        error: "Instagram is not connected",
+      } as const;
+    }
+
+    const fallback = buildFallbackPreview(integration.username);
+
+    const conversations = await fetchConversationsForSync({
+      accessToken: integration.accessToken,
+      igUserId: integration.instagramUserId,
+    }).catch((error) => {
+      console.error("Error fetching Instagram preview conversations:", error);
+      return [] as InstagramConversation[];
+    });
+
+    const recentConversations = conversations
+      .filter((conversation) => Array.isArray(conversation.messages?.data))
+      .slice(0, 12);
+
+    const previewConversation = recentConversations.find((conversation) => {
+      return (
+        Array.isArray(conversation.messages?.data) &&
+        conversation.messages.data.some(
+          (message) =>
+            typeof message.message === "string" &&
+            message.message.trim().length > 0,
+        )
+      );
+    });
+
+    if (!previewConversation?.messages?.data?.length) {
+      return {
+        success: true,
+        connected: true,
+        data: fallback,
+      } as const;
+    }
+
+    const leadParticipant = getLeadParticipant(previewConversation, {
+      appScopedUserId: integration.appScopedUserId,
+      instagramUserId: integration.instagramUserId,
+      username: integration.username,
+    }) ?? {
+      id: "lead",
+      username: userData?.name ? `${userData.name}'s lead` : "Lead",
+    };
+
+    const previewMessages = formatPreviewMessages({
+      businessUsername: integration.username,
+      leadName: leadParticipant.username,
+      messages: previewConversation.messages.data,
+    });
+
+    if (previewMessages.length === 0) {
+      return {
+        success: true,
+        connected: true,
+        data: fallback,
+      } as const;
+    }
+
+    const conversationContext = buildConversationContext(previewMessages);
+    const fallbackReply =
+      "Absolutely. I can walk you through the details here and help you figure out the best next step.";
+    const replyPreview = await buildReplyPreview({
+      conversationContext,
+      fallbackReply,
+      userId: session.user.id,
+    });
+
+    const pulledDmCount = Math.min(
+      recentConversations.reduce((total, conversation) => {
+        return (
+          total +
+          (Array.isArray(conversation.messages?.data)
+            ? conversation.messages.data.filter(
+                (message) =>
+                  typeof message.message === "string" &&
+                  message.message.trim().length > 0,
+              ).length
+            : 0)
+        );
+      }, 0),
+      20,
+    );
+
+    return {
+      success: true,
+      connected: true,
+      data: {
+        accountUsername: integration.username,
+        conversationCount: recentConversations.length,
+        previewMessages,
+        previewTarget: leadParticipant.username,
+        pulledDmCount,
+        replyPreview,
+        source: "live",
+      },
+    } as const;
+  } catch (error) {
+    console.error("Error preparing Instagram preview:", error);
+    return {
+      success: false,
+      connected: true,
+      error: "Failed to prepare your Instagram preview",
+    } as const;
   }
 }

--- a/apps/app/src/app/(onboarding)/onboarding/page.tsx
+++ b/apps/app/src/app/(onboarding)/onboarding/page.tsx
@@ -892,14 +892,8 @@ function OnboardingPageContent() {
                                   : "bg-background text-foreground"
                               }`}
                             >
-                              <p className="text-xs font-medium opacity-70">
-                                {message.sender}
-                              </p>
                               <p className="mt-1 text-sm leading-relaxed">
                                 {message.text}
-                              </p>
-                              <p className="mt-2 text-[11px] opacity-60">
-                                {formatPreviewTimestamp(message.timestamp)}
                               </p>
                             </div>
                           </div>

--- a/apps/app/src/app/(onboarding)/onboarding/page.tsx
+++ b/apps/app/src/app/(onboarding)/onboarding/page.tsx
@@ -375,18 +375,6 @@ async function submitStep2Action(
   }
 }
 
-function formatPreviewTimestamp(timestamp: string) {
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) {
-    return "Now";
-  }
-
-  return date.toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
 function OnboardingPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -519,7 +507,8 @@ function OnboardingPageContent() {
       activeStep !== 1 ||
       !instagramConnection.connected ||
       instagramPreview ||
-      isPreparingPreview
+      isPreparingPreview ||
+      previewError
     ) {
       return;
     }
@@ -559,6 +548,7 @@ function OnboardingPageContent() {
     instagramConnection.connected,
     instagramPreview,
     isPreparingPreview,
+    previewError,
   ]);
 
   const handleStep0Submit = (values: Step0FormValues) =>

--- a/apps/app/src/app/(onboarding)/onboarding/page.tsx
+++ b/apps/app/src/app/(onboarding)/onboarding/page.tsx
@@ -1,13 +1,33 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm, useWatch, type UseFormReturn } from "react-hook-form";
 import { toast } from "sonner";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Loader2,
+  MessageCircleMore,
+  Sparkles,
+} from "lucide-react";
 
-import { Card, CardContent } from "@pilot/ui/components/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@pilot/ui/components/card";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@pilot/ui/components/alert";
+import { Badge } from "@pilot/ui/components/badge";
+import { Button } from "@pilot/ui/components/button";
 import {
   Form,
   FormControl,
@@ -19,6 +39,7 @@ import {
 } from "@pilot/ui/components/form";
 import { Input } from "@pilot/ui/components/input";
 import { RadioGroup, RadioGroupItem } from "@pilot/ui/components/radio-group";
+import { Skeleton } from "@pilot/ui/components/skeleton";
 import {
   Stepper,
   StepperIndicator,
@@ -27,28 +48,65 @@ import {
   StepperTitle,
   StepperTrigger,
 } from "@pilot/ui/components/stepper";
-import { StepButtons } from "@/components/step-buttons";
 import { Checkbox } from "@pilot/ui/components/checkbox";
 
+import { StepButtons } from "@/components/step-buttons";
 import {
-  steps,
-  gender_options,
-  use_case_options,
-  leads_per_month_options,
   active_platforms_options,
   business_type_options,
-  pilot_goal_options,
   current_tracking_options,
+  gender_options,
+  leads_per_month_options,
+  pilot_goal_options,
+  steps,
+  use_case_options,
 } from "@/lib/constants/onboarding";
 import {
-  updateOnboardingStep,
-  completeOnboarding,
   checkOnboardingStatus,
+  completeOnboarding,
+  getInstagramOnboardingState,
   getUserData,
+  prepareInstagramPreview,
+  updateOnboardingStep,
 } from "@/actions/onboarding";
 import { optionToValue } from "@/lib/utils";
 import { authClient } from "@/lib/auth-client";
-import type { UseFormReturn } from "react-hook-form";
+
+const onboardingSteps = [
+  { id: 0, name: "Instagram" },
+  { id: 1, name: "Preview" },
+  ...steps.map((step, index) => ({
+    id: index + 2,
+    name: step.name,
+  })),
+];
+
+const setupProgressCopy = [
+  "Pulling your last 10-20 DMs",
+  "Mapping the basic metadata",
+  "Drafting your first Sidekick reply",
+] as const;
+
+type InstagramConnectionState = {
+  connected: boolean;
+  error?: string;
+  username?: string;
+};
+
+type InstagramPreviewState = {
+  accountUsername: string;
+  conversationCount: number;
+  previewMessages: Array<{
+    direction: "incoming" | "outgoing";
+    sender: string;
+    text: string;
+    timestamp: string;
+  }>;
+  previewTarget: string;
+  pulledDmCount: number;
+  replyPreview: string;
+  source: "live" | "starter";
+};
 
 const step0Schema = z.object({
   name: z.string().min(1, { message: "Please enter your name" }),
@@ -90,8 +148,10 @@ async function checkOnboardingStatusAndPrefill(
   step0Form: UseFormReturn<Step0FormValues>,
   step1Form: UseFormReturn<Step1FormValues>,
   step2Form: UseFormReturn<Step2FormValues>,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  setIsInitializing: (v: boolean) => void
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  setIsInitializing: (value: boolean) => void,
 ) {
   try {
     const status = await checkOnboardingStatus();
@@ -100,90 +160,85 @@ async function checkOnboardingStatusAndPrefill(
     }
 
     const userDataResult = await getUserData();
-    if (userDataResult.success && userDataResult.userData) {
-      if (userDataResult.userData.name) {
-        step0Form.setValue("name", userDataResult.userData.name);
-      }
-      if (userDataResult.userData.gender) {
-        step0Form.setValue("gender", userDataResult.userData.gender);
-      }
+    if (!userDataResult.success || !userDataResult.userData) {
+      return;
+    }
 
-      if (userDataResult.userData.use_case) {
-        step1Form.setValue("use_case", userDataResult.userData.use_case);
-      }
-      if (userDataResult.userData.other_use_case) {
-        step1Form.setValue(
-          "other_use_case",
-          userDataResult.userData.other_use_case
-        );
-      }
-      if (userDataResult.userData.leads_per_month) {
-        step1Form.setValue(
-          "leads_per_month",
-          userDataResult.userData.leads_per_month
-        );
-      }
-      if (userDataResult.userData.active_platforms) {
-        step1Form.setValue(
-          "active_platforms",
-          userDataResult.userData.active_platforms
-        );
-      }
-      if (userDataResult.userData.other_platform) {
-        step1Form.setValue(
-          "other_platform",
-          userDataResult.userData.other_platform
-        );
-      }
+    if (userDataResult.userData.name) {
+      step0Form.setValue("name", userDataResult.userData.name);
+    }
+    if (userDataResult.userData.gender) {
+      step0Form.setValue("gender", userDataResult.userData.gender);
+    }
 
-      if (userDataResult.userData.business_type) {
-        step2Form.setValue(
-          "business_type",
-          userDataResult.userData.business_type
-        );
-      }
-      if (userDataResult.userData.other_business_type) {
-        step2Form.setValue(
-          "other_business_type",
-          userDataResult.userData.other_business_type
-        );
-      }
-      if (userDataResult.userData.pilot_goal) {
-        step2Form.setValue(
-          "pilot_goal",
-          userDataResult.userData.pilot_goal
-        );
-      }
-      if (userDataResult.userData.current_tracking) {
-        step2Form.setValue(
-          "current_tracking",
-          userDataResult.userData.current_tracking
-        );
-      }
-      if (userDataResult.userData.other_tracking) {
-        step2Form.setValue(
-          "other_tracking",
-          userDataResult.userData.other_tracking
-        );
-      }
+    if (userDataResult.userData.use_case) {
+      step1Form.setValue("use_case", userDataResult.userData.use_case);
+    }
+    if (userDataResult.userData.other_use_case) {
+      step1Form.setValue(
+        "other_use_case",
+        userDataResult.userData.other_use_case,
+      );
+    }
+    if (userDataResult.userData.leads_per_month) {
+      step1Form.setValue(
+        "leads_per_month",
+        userDataResult.userData.leads_per_month,
+      );
+    }
+    if (userDataResult.userData.active_platforms) {
+      step1Form.setValue(
+        "active_platforms",
+        userDataResult.userData.active_platforms,
+      );
+    }
+    if (userDataResult.userData.other_platform) {
+      step1Form.setValue(
+        "other_platform",
+        userDataResult.userData.other_platform,
+      );
+    }
 
-      const step0Valid =
-        !!userDataResult.userData.name && !!userDataResult.userData.gender;
-      const step1Valid =
+    if (userDataResult.userData.business_type) {
+      step2Form.setValue(
+        "business_type",
+        userDataResult.userData.business_type,
+      );
+    }
+    if (userDataResult.userData.other_business_type) {
+      step2Form.setValue(
+        "other_business_type",
+        userDataResult.userData.other_business_type,
+      );
+    }
+    if (userDataResult.userData.pilot_goal) {
+      step2Form.setValue("pilot_goal", userDataResult.userData.pilot_goal);
+    }
+    if (userDataResult.userData.current_tracking) {
+      step2Form.setValue(
+        "current_tracking",
+        userDataResult.userData.current_tracking,
+      );
+    }
+    if (userDataResult.userData.other_tracking) {
+      step2Form.setValue(
+        "other_tracking",
+        userDataResult.userData.other_tracking,
+      );
+    }
+
+    setStepValidationState((previousState) => ({
+      ...previousState,
+      2: !!userDataResult.userData.name && !!userDataResult.userData.gender,
+      3:
         !!userDataResult.userData.use_case?.length &&
         !!userDataResult.userData.leads_per_month &&
-        !!userDataResult.userData.active_platforms?.length;
-      const step2Valid =
+        !!userDataResult.userData.active_platforms?.length,
+      4:
         !!userDataResult.userData.business_type &&
         !!userDataResult.userData.pilot_goal?.length &&
-        !!userDataResult.userData.current_tracking?.length;
-
-      setStepValidationState({
-        0: step0Valid,
-        1: step1Valid,
-        2: step2Valid,
-      });
-    }
+        !!userDataResult.userData.current_tracking?.length,
+    }));
   } catch (error) {
     console.error("Error checking onboarding status:", error);
   } finally {
@@ -191,24 +246,53 @@ async function checkOnboardingStatusAndPrefill(
   }
 }
 
+async function checkInstagramConnectionAction(
+  setInstagramConnection: React.Dispatch<
+    React.SetStateAction<InstagramConnectionState>
+  >,
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  setActiveStep: React.Dispatch<React.SetStateAction<number>>,
+) {
+  try {
+    const result = await getInstagramOnboardingState();
+    setInstagramConnection(result);
+    setStepValidationState((previousState) => ({
+      ...previousState,
+      0: result.connected,
+    }));
+
+    if (result.connected) {
+      setActiveStep((currentStep) => Math.max(currentStep, 1));
+    }
+  } catch (error) {
+    console.error("Error checking Instagram connection:", error);
+    setInstagramConnection({
+      connected: false,
+      error: "Failed to check Instagram connection",
+    });
+  }
+}
+
 async function submitStep0Action(
   values: Step0FormValues,
-  setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  onSuccess: () => void
+  setIsLoading: (value: boolean) => void,
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  onSuccess: () => void,
 ) {
   try {
     setIsLoading(true);
     const result = await updateOnboardingStep(values);
 
     if (!result.success) {
-      toast.error(
-        result.error || "Oops! Couldn't save your info. Try again?"
-      );
+      toast.error(result.error || "Oops! Couldn't save your info. Try again?");
       return;
     }
 
-    setStepValidationState((prevState) => ({ ...prevState, 0: true }));
+    setStepValidationState((previousState) => ({ ...previousState, 2: true }));
     onSuccess();
     toast.success("Saved. Next step.");
   } catch (error) {
@@ -221,9 +305,11 @@ async function submitStep0Action(
 
 async function submitStep1Action(
   values: Step1FormValues,
-  setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  onSuccess: () => void
+  setIsLoading: (value: boolean) => void,
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  onSuccess: () => void,
 ) {
   try {
     setIsLoading(true);
@@ -232,12 +318,12 @@ async function submitStep1Action(
     if (!result.success) {
       toast.error(
         result.error ||
-        "Failed to save your usage preferences. Please try again."
+          "Failed to save your usage preferences. Please try again.",
       );
       return;
     }
 
-    setStepValidationState((prevState) => ({ ...prevState, 1: true }));
+    setStepValidationState((previousState) => ({ ...previousState, 3: true }));
     onSuccess();
     toast.success("Saved. One more step.");
   } catch (error) {
@@ -250,9 +336,11 @@ async function submitStep1Action(
 
 async function submitStep2Action(
   values: Step2FormValues,
-  setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  router: { push: (url: string) => void }
+  setIsLoading: (value: boolean) => void,
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  router: { push: (url: string) => void },
 ) {
   try {
     setIsLoading(true);
@@ -261,24 +349,24 @@ async function submitStep2Action(
     if (!updateResult.success) {
       toast.error(
         updateResult.error ||
-        "Failed to save your business details. Please try again."
+          "Failed to save your business details. Please try again.",
       );
       return;
     }
 
-    setStepValidationState((prevState) => ({ ...prevState, 2: true }));
+    setStepValidationState((previousState) => ({ ...previousState, 4: true }));
 
     const completeResult = await completeOnboarding();
     if (!completeResult.success) {
       toast.error(
         completeResult.error ||
-        "Failed to complete onboarding. Please try again."
+          "Failed to complete onboarding. Please try again.",
       );
       return;
     }
 
-    toast.success("Setup complete. Welcome to Pilot.");
-    router.push("/");
+    toast.success("Quick setup complete. Next up: Sidekick.");
+    router.push("/sidekick-onboarding");
   } catch (error) {
     console.error("Error submitting step 2:", error);
     toast.error("Hmm, something's not right. Give it another shot?");
@@ -287,23 +375,46 @@ async function submitStep2Action(
   }
 }
 
-export default function OnboardingPage() {
+function formatPreviewTimestamp(timestamp: string) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return "Now";
+  }
+
+  return date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function OnboardingPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [activeStep, setActiveStep] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
+  const [isConnectingInstagram, setIsConnectingInstagram] = useState(false);
+  const [isPreparingPreview, setIsPreparingPreview] = useState(false);
+  const [previewProgress, setPreviewProgress] = useState(0);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [instagramConnection, setInstagramConnection] =
+    useState<InstagramConnectionState>({
+      connected: false,
+    });
+  const [instagramPreview, setInstagramPreview] =
+    useState<InstagramPreviewState | null>(null);
   const [stepValidationState, setStepValidationState] = useState<
     Record<number, boolean>
   >({
     0: false,
     1: false,
     2: false,
+    3: false,
+    4: false,
   });
 
   const session = authClient.useSession();
-
   const userData = {
-    name: session?.data?.user?.name || "",
     email: session?.data?.user?.email || "",
   };
 
@@ -337,44 +448,181 @@ export default function OnboardingPage() {
     },
   });
 
-  useEffect(() => {
-    checkOnboardingStatusAndPrefill(router, step0Form, step1Form, step2Form, setStepValidationState, setIsInitializing);
-  }, []); // intentionally run once on mount -- form refs and router are stable at init time
+  const watchedUseCase = useWatch({
+    control: step1Form.control,
+    name: "use_case",
+  });
+  const watchedActivePlatforms = useWatch({
+    control: step1Form.control,
+    name: "active_platforms",
+  });
+  const watchedBusinessType = useWatch({
+    control: step2Form.control,
+    name: "business_type",
+  });
+  const watchedCurrentTracking = useWatch({
+    control: step2Form.control,
+    name: "current_tracking",
+  });
 
-  const watchedUseCase = useWatch({ control: step1Form.control, name: "use_case" });
-  const watchedActivePlatforms = useWatch({ control: step1Form.control, name: "active_platforms" });
-  const watchedBusinessType = useWatch({ control: step2Form.control, name: "business_type" });
-  const watchedCurrentTracking = useWatch({ control: step2Form.control, name: "current_tracking" });
+  useEffect(() => {
+    checkOnboardingStatusAndPrefill(
+      router,
+      step0Form,
+      step1Form,
+      step2Form,
+      setStepValidationState,
+      setIsInitializing,
+    );
+    checkInstagramConnectionAction(
+      setInstagramConnection,
+      setStepValidationState,
+      setActiveStep,
+    );
+  }, []);
+
+  useEffect(() => {
+    const success = searchParams.get("success");
+    const error = searchParams.get("error");
+
+    if (success === "instagram_connected") {
+      toast.success("Instagram connected.");
+      checkInstagramConnectionAction(
+        setInstagramConnection,
+        setStepValidationState,
+        setActiveStep,
+      );
+    }
+
+    if (error) {
+      toast.error(`Instagram connection failed: ${error}`);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!isPreparingPreview) {
+      return;
+    }
+
+    const timers = [
+      window.setTimeout(() => setPreviewProgress(1), 700),
+      window.setTimeout(() => setPreviewProgress(2), 1400),
+    ];
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, [isPreparingPreview]);
+
+  useEffect(() => {
+    if (
+      activeStep !== 1 ||
+      !instagramConnection.connected ||
+      instagramPreview ||
+      isPreparingPreview
+    ) {
+      return;
+    }
+
+    async function loadPreview() {
+      setPreviewError(null);
+      setPreviewProgress(0);
+      setStepValidationState((previousState) => ({
+        ...previousState,
+        1: false,
+      }));
+      setIsPreparingPreview(true);
+      const result = await prepareInstagramPreview().catch((error) => {
+        console.error("Error preparing onboarding preview:", error);
+        return null;
+      });
+
+      if (!result || !result.success || !result.connected || !result.data) {
+        setPreviewError(
+          result?.error || "We couldn't prepare your preview yet.",
+        );
+        setIsPreparingPreview(false);
+        return;
+      }
+
+      setInstagramPreview(result.data);
+      setStepValidationState((previousState) => ({
+        ...previousState,
+        1: true,
+      }));
+      setIsPreparingPreview(false);
+    }
+
+    loadPreview();
+  }, [
+    activeStep,
+    instagramConnection.connected,
+    instagramPreview,
+    isPreparingPreview,
+  ]);
 
   const handleStep0Submit = (values: Step0FormValues) =>
-    submitStep0Action(values, setIsLoading, setStepValidationState, handleNext);
+    submitStep0Action(values, setIsLoading, setStepValidationState, () => {
+      setActiveStep(3);
+    });
 
   const handleStep1Submit = (values: Step1FormValues) =>
-    submitStep1Action(values, setIsLoading, setStepValidationState, handleNext);
+    submitStep1Action(values, setIsLoading, setStepValidationState, () => {
+      setActiveStep(4);
+    });
 
   const handleStep2Submit = (values: Step2FormValues) =>
     submitStep2Action(values, setIsLoading, setStepValidationState, router);
 
   const handleBack = () => {
-    setActiveStep(prev => prev - 1);
+    setActiveStep((previousStep) => previousStep - 1);
   };
 
-  const handleNext = () => {
-    setActiveStep(prev => prev + 1);
+  const handleInstagramConnect = () => {
+    setIsConnectingInstagram(true);
+    window.location.href = "/api/auth/instagram?returnTo=/onboarding";
+  };
+
+  const handleRefreshPreview = async () => {
+    setInstagramPreview(null);
+    setPreviewError(null);
+    setPreviewProgress(0);
+    setStepValidationState((previousState) => ({
+      ...previousState,
+      1: false,
+    }));
+    setIsPreparingPreview(true);
+    const result = await prepareInstagramPreview().catch((error) => {
+      console.error("Error refreshing onboarding preview:", error);
+      return null;
+    });
+
+    if (!result || !result.success || !result.connected || !result.data) {
+      setPreviewError(result?.error || "We couldn't prepare your preview yet.");
+      setIsPreparingPreview(false);
+      return;
+    }
+
+    setInstagramPreview(result.data);
+    setStepValidationState((previousState) => ({
+      ...previousState,
+      1: true,
+    }));
+    setIsPreparingPreview(false);
   };
 
   if (isInitializing) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex h-full items-center justify-center">
         <p>Loading your setup...</p>
       </div>
     );
   }
 
   return (
-    <section className="w-full max-w-5xl px-4 py-6 overflow-y-auto">
-      <Card className="shadow-md border-border">
-        <CardContent className="space-y-6">
+    <section className="w-full max-w-5xl overflow-y-auto px-4 py-6">
+      <Card className="border-border shadow-md">
+        <CardContent className="space-y-6 pt-6">
           <Stepper
             value={activeStep}
             onValueChange={(newStep) => {
@@ -383,16 +631,16 @@ export default function OnboardingPage() {
                 return;
               }
 
-              if (newStep === activeStep + 1) {
-                const isValid = stepValidationState[activeStep];
-                if (isValid) {
-                  setActiveStep(newStep);
-                }
+              if (
+                newStep === activeStep + 1 &&
+                stepValidationState[activeStep]
+              ) {
+                setActiveStep(newStep);
               }
             }}
-            className="px-2 sm:px-6 py-2"
+            className="px-2 py-2 sm:px-6"
           >
-            {steps.map((step, index) => (
+            {onboardingSteps.map((step, index) => (
               <StepperItem
                 key={step.id}
                 step={step.id}
@@ -401,30 +649,294 @@ export default function OnboardingPage() {
                   (step.id > activeStep && !stepValidationState[activeStep])
                 }
                 completed={activeStep > step.id}
-                loading={isLoading && step.id === activeStep}
+                loading={
+                  (isLoading && step.id >= 2 && step.id === activeStep) ||
+                  (isPreparingPreview && step.id === 1)
+                }
                 className="relative flex-1 !flex-col"
               >
                 <StepperTrigger className="flex-col gap-3">
                   <StepperIndicator />
-                  <div className="space-y-0.5 px-2">
+                  <div className="px-2">
                     <StepperTitle>{step.name}</StepperTitle>
                   </div>
                 </StepperTrigger>
-                {index < steps.length - 1 && (
-                  <StepperSeparator className="absolute inset-x-0 left-[calc(50%+0.75rem+0.750rem)] top-6 -order-1 m-0 -translate-y-1/2 group-data-[orientation=horizontal]/stepper:w-[calc(100%-3rem)] group-data-[orientation=horizontal]/stepper:flex-none" />
-                )}
+                {index < onboardingSteps.length - 1 ? (
+                  <StepperSeparator className="absolute inset-x-0 top-6 -order-1 m-0 left-[calc(50%+0.75rem+0.750rem)] -translate-y-1/2 group-data-[orientation=horizontal]/stepper:w-[calc(100%-3rem)] group-data-[orientation=horizontal]/stepper:flex-none" />
+                ) : null}
               </StepperItem>
             ))}
           </Stepper>
 
-          <div className="border border-border p-6 rounded-xl shadow-sm">
-            {activeStep === 0 && (
+          {activeStep === 0 ? (
+            <Card className="overflow-hidden border-border bg-card text-card-foreground shadow-none">
+              <div className="grid gap-8 p-6 md:grid-cols-[1.2fr_0.8fr] md:p-8">
+                <div className="flex flex-col gap-3">
+                  <h2 className="max-w-lg text-3xl font-semibold font-heading leading-tight">
+                    Turn your next DM into revenue in 2 minutes.
+                  </h2>
+                  <p className="max-w-md text-sm text-muted-foreground">
+                    Connect Instagram first so Pilot can show you what the
+                    product feels like before asking for setup details.
+                  </p>
+                </div>
+
+                <div className="flex flex-col justify-center gap-4 rounded-xl border bg-muted/40 p-6">
+                  {instagramConnection.error ? (
+                    <Alert>
+                      <Sparkles data-icon="inline-start" />
+                      <AlertTitle>Connection issue</AlertTitle>
+                      <AlertDescription>
+                        {instagramConnection.error}
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+
+                  <Button
+                    type="button"
+                    size="lg"
+                    className="h-12 w-full"
+                    disabled={isConnectingInstagram}
+                    onClick={handleInstagramConnect}
+                  >
+                    {isConnectingInstagram ? (
+                      <Loader2
+                        className="animate-spin"
+                        data-icon="inline-start"
+                      />
+                    ) : null}
+                    Connect Instagram
+                  </Button>
+
+                  <p className="text-center text-sm text-muted-foreground">
+                    We&apos;ll only read DMs to train your AI.
+                  </p>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
+          {activeStep === 1 ? (
+            <Card className="border-border/80 shadow-none">
+              <CardHeader className="gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex flex-col gap-2">
+                    <CardTitle className="text-2xl font-heading">
+                      Setting things up...
+                    </CardTitle>
+                    <CardDescription>
+                      We&apos;re pulling recent Instagram context and showing
+                      you how Sidekick would jump into a real thread.
+                    </CardDescription>
+                  </div>
+                  {instagramConnection.username ? (
+                    <Badge variant="secondary">
+                      @{instagramConnection.username}
+                    </Badge>
+                  ) : null}
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-6">
+                {isPreparingPreview ? (
+                  <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+                    <div className="flex flex-col gap-3 rounded-xl border bg-muted/40 p-4">
+                      {setupProgressCopy.map((copy, index) => (
+                        <div
+                          key={copy}
+                          className="flex items-center gap-3 rounded-lg border border-border/60 bg-background/70 px-3 py-3"
+                        >
+                          {previewProgress > index ? (
+                            <CheckCircle2 className="text-primary" />
+                          ) : (
+                            <Loader2 className="animate-spin text-muted-foreground" />
+                          )}
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium">{copy}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {index === 0
+                                ? "Recent threads"
+                                : index === 1
+                                  ? "Timestamps and participants"
+                                  : "1-2 sentence reply preview"}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className="flex flex-col gap-4 rounded-xl border p-4">
+                      <div className="flex items-center justify-between">
+                        <Skeleton className="h-5 w-28" />
+                        <Skeleton className="h-5 w-20" />
+                      </div>
+                      <div className="flex flex-col gap-3">
+                        <Skeleton className="h-16 w-4/5 self-start rounded-2xl" />
+                        <Skeleton className="h-14 w-3/5 self-end rounded-2xl" />
+                        <Skeleton className="h-16 w-2/3 self-start rounded-2xl" />
+                      </div>
+                      <Skeleton className="h-px w-full" />
+                      <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4">
+                        <Skeleton className="h-4 w-28" />
+                        <Skeleton className="mt-3 h-12 w-full" />
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                {!isPreparingPreview && previewError ? (
+                  <Alert>
+                    <MessageCircleMore data-icon="inline-start" />
+                    <AlertTitle>Preview not ready yet</AlertTitle>
+                    <AlertDescription>
+                      <p>{previewError}</p>
+                      <Button
+                        type="button"
+                        variant="link"
+                        className="mt-1 h-auto px-0"
+                        onClick={handleRefreshPreview}
+                      >
+                        Try again
+                      </Button>
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+
+                {!isPreparingPreview && instagramPreview ? (
+                  <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+                    <div className="flex flex-col gap-4">
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-xl border bg-muted/40 p-4">
+                          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                            Recent DMs
+                          </p>
+                          <p className="mt-2 text-3xl font-semibold">
+                            {instagramPreview.pulledDmCount}
+                          </p>
+                        </div>
+                        <div className="rounded-xl border bg-muted/40 p-4">
+                          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                            Conversations
+                          </p>
+                          <p className="mt-2 text-3xl font-semibold">
+                            {instagramPreview.conversationCount}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="rounded-xl border p-4">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-medium">
+                              Here&apos;s how Sidekick would reply to this
+                              message.
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              First preview for @
+                              {instagramPreview.accountUsername}
+                            </p>
+                          </div>
+                          {instagramPreview.source === "starter" ? (
+                            <Badge variant="outline">Starter preview</Badge>
+                          ) : (
+                            <Badge variant="secondary">Live preview</Badge>
+                          )}
+                        </div>
+                      </div>
+
+                      {instagramPreview.source === "starter" ? (
+                        <Alert>
+                          <Sparkles data-icon="inline-start" />
+                          <AlertTitle>Starter preview</AlertTitle>
+                          <AlertDescription>
+                            We&apos;ll swap this for live thread data as more
+                            DMs sync in.
+                          </AlertDescription>
+                        </Alert>
+                      ) : null}
+                    </div>
+
+                    <div className="flex flex-col gap-4 rounded-xl border p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="font-medium">
+                            DM with {instagramPreview.previewTarget}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Pilot previews the thread, then drafts the reply.
+                          </p>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleRefreshPreview}
+                        >
+                          Refresh
+                        </Button>
+                      </div>
+
+                      <div className="flex flex-col gap-3 rounded-xl bg-muted/40 p-3">
+                        {instagramPreview.previewMessages.map((message) => (
+                          <div
+                            key={`${message.timestamp}-${message.sender}-${message.text}`}
+                            className={`flex ${
+                              message.direction === "outgoing"
+                                ? "justify-end"
+                                : "justify-start"
+                            }`}
+                          >
+                            <div
+                              className={`max-w-[85%] rounded-2xl px-4 py-3 ${
+                                message.direction === "outgoing"
+                                  ? "bg-primary text-primary-foreground"
+                                  : "bg-background text-foreground"
+                              }`}
+                            >
+                              <p className="text-xs font-medium opacity-70">
+                                {message.sender}
+                              </p>
+                              <p className="mt-1 text-sm leading-relaxed">
+                                {message.text}
+                              </p>
+                              <p className="mt-2 text-[11px] opacity-60">
+                                {formatPreviewTimestamp(message.timestamp)}
+                              </p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4">
+                        <div className="flex items-center gap-2">
+                          <Sparkles className="text-primary" />
+                          <p className="text-sm font-medium">Reply preview</p>
+                        </div>
+                        <p className="mt-3 text-sm leading-relaxed">
+                          {instagramPreview.replyPreview}
+                        </p>
+                      </div>
+
+                      <div className="flex justify-end">
+                        <Button type="button" onClick={() => setActiveStep(2)}>
+                          Continue
+                          <ArrowRight data-icon="inline-end" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {activeStep === 2 ? (
+            <div className="rounded-xl border border-border p-6 shadow-sm">
               <Form {...step0Form}>
                 <form
                   onSubmit={step0Form.handleSubmit(handleStep0Submit)}
                   className="space-y-6"
                 >
-                  <h2 className="text-xl font-semibold font-heading">
+                  <h2 className="font-heading text-xl font-semibold">
                     Tell Us About You
                   </h2>
 
@@ -462,7 +974,7 @@ export default function OnboardingPage() {
                           <RadioGroup
                             onValueChange={field.onChange}
                             value={field.value}
-                            className="grid grid-cols-2 sm:grid-cols-4 gap-3"
+                            className="grid grid-cols-2 gap-3 sm:grid-cols-4"
                           >
                             {gender_options.map((option) => (
                               <FormItem
@@ -478,17 +990,19 @@ export default function OnboardingPage() {
                                 </FormControl>
                                 <FormLabel
                                   htmlFor={`gender-${option}`}
-                                  className={`border rounded-lg p-3 w-full flex items-center gap-2 cursor-pointer transition-all ${field.value === option
-                                    ? "border-primary bg-primary/10"
-                                    : "border-border hover:border-muted-foreground"
-                                    }`}
+                                  className={`flex w-full cursor-pointer items-center gap-2 rounded-lg border p-3 transition-all ${
+                                    field.value === option
+                                      ? "border-primary bg-primary/10"
+                                      : "border-border hover:border-muted-foreground"
+                                  }`}
                                 >
                                   <div
-                                    className={`size-4 rounded-full border ${field.value === option
-                                      ? "border-4 border-primary"
-                                      : "border border-muted-foreground"
-                                      }`}
-                                  ></div>
+                                    className={`size-4 rounded-full border ${
+                                      field.value === option
+                                        ? "border-4 border-primary"
+                                        : "border border-muted-foreground"
+                                    }`}
+                                  />
                                   <span>{option}</span>
                                 </FormLabel>
                               </FormItem>
@@ -503,15 +1017,19 @@ export default function OnboardingPage() {
                   <StepButtons showBack={false} isLoading={isLoading} />
                 </form>
               </Form>
-            )}
+            </div>
+          ) : null}
 
-            {activeStep === 1 && (
+          {activeStep === 3 ? (
+            <div className="rounded-xl border border-border p-6 shadow-sm">
               <Form {...step1Form}>
                 <form
                   onSubmit={step1Form.handleSubmit(handleStep1Submit)}
                   className="space-y-6"
                 >
-                  <h2 className="text-xl font-semibold font-heading">How You Use Pilot</h2>
+                  <h2 className="font-heading text-xl font-semibold">
+                    How You Use Pilot
+                  </h2>
 
                   <FormField
                     control={step1Form.control}
@@ -519,9 +1037,10 @@ export default function OnboardingPage() {
                     render={({ field }) => (
                       <FormItem className="space-y-3">
                         <FormLabel>What will you use Pilot for?</FormLabel>
-                        <div className="space-y-2">
+                        <div className="flex flex-col gap-2">
                           {use_case_options.map((option) => {
                             const value = optionToValue(option);
+
                             return (
                               <FormItem
                                 key={value}
@@ -534,8 +1053,9 @@ export default function OnboardingPage() {
                                       const updatedValue = checked
                                         ? [...field.value, value]
                                         : field.value.filter(
-                                          (val) => val !== value
-                                        );
+                                            (currentValue) =>
+                                              currentValue !== value,
+                                          );
                                       field.onChange(updatedValue);
                                     }}
                                   />
@@ -552,7 +1072,7 @@ export default function OnboardingPage() {
                     )}
                   />
 
-                  {watchedUseCase?.includes("other") && (
+                  {watchedUseCase?.includes("other") ? (
                     <FormField
                       control={step1Form.control}
                       name="other_use_case"
@@ -566,7 +1086,7 @@ export default function OnboardingPage() {
                         </FormItem>
                       )}
                     />
-                  )}
+                  ) : null}
 
                   <FormField
                     control={step1Form.control}
@@ -580,7 +1100,7 @@ export default function OnboardingPage() {
                           <RadioGroup
                             onValueChange={field.onChange}
                             value={field.value}
-                            className="grid grid-cols-2 sm:grid-cols-4 gap-3"
+                            className="grid grid-cols-2 gap-3 sm:grid-cols-4"
                           >
                             {leads_per_month_options.map((option) => (
                               <FormItem
@@ -596,18 +1116,13 @@ export default function OnboardingPage() {
                                 </FormControl>
                                 <FormLabel
                                   htmlFor={`leads-${option}`}
-                                  className={`border rounded-lg p-3 w-full flex items-center gap-2 cursor-pointer transition-all ${field.value === option
-                                    ? "border-primary bg-primary/10"
-                                    : "border-border hover:border-muted-foreground"
-                                    }`}
+                                  className={`flex w-full cursor-pointer items-center justify-center rounded-lg border p-3 text-center transition-all ${
+                                    field.value === option
+                                      ? "border-primary bg-primary/10"
+                                      : "border-border hover:border-muted-foreground"
+                                  }`}
                                 >
-                                  <div
-                                    className={`size-4 rounded-full border ${field.value === option
-                                      ? "border-4 border-primary"
-                                      : "border border-muted-foreground"
-                                      }`}
-                                  ></div>
-                                  <span>{option}</span>
+                                  {option}
                                 </FormLabel>
                               </FormItem>
                             ))}
@@ -623,16 +1138,15 @@ export default function OnboardingPage() {
                     name="active_platforms"
                     render={({ field }) => (
                       <FormItem className="space-y-3">
-                        <FormLabel>
-                          Which platforms are you active on?
-                        </FormLabel>
-                        <div className="space-y-2">
+                        <FormLabel>Where are you active?</FormLabel>
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                           {active_platforms_options.map((option) => {
                             const value = optionToValue(option);
+
                             return (
                               <FormItem
                                 key={value}
-                                className="flex flex-row items-start space-x-3 space-y-0"
+                                className="flex flex-row items-start space-x-3 space-y-0 rounded-lg border p-3"
                               >
                                 <FormControl>
                                   <Checkbox
@@ -641,8 +1155,9 @@ export default function OnboardingPage() {
                                       const updatedValue = checked
                                         ? [...field.value, value]
                                         : field.value.filter(
-                                          (val) => val !== value
-                                        );
+                                            (currentValue) =>
+                                              currentValue !== value,
+                                          );
                                       field.onChange(updatedValue);
                                     }}
                                   />
@@ -654,102 +1169,19 @@ export default function OnboardingPage() {
                             );
                           })}
                         </div>
-                        <FormDescription>
-                          This helps us set up filters and automations that fit your workflow.
-                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
 
-                  {watchedActivePlatforms?.includes("other") && (
+                  {watchedActivePlatforms?.includes("other") ? (
                     <FormField
                       control={step1Form.control}
                       name="other_platform"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Tell us the platform</FormLabel>
-                          <FormControl>
-                            <Input {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  )}
-
-                  <StepButtons isLoading={isLoading} onBack={handleBack} />
-                </form>
-              </Form>
-            )}
-
-            {activeStep === 2 && (
-              <Form {...step2Form}>
-                <form
-                  onSubmit={step2Form.handleSubmit(handleStep2Submit)}
-                  className="space-y-6"
-                >
-                  <h2 className="text-xl font-semibold font-heading">Business And Goals</h2>
-
-                  <FormField
-                    control={step2Form.control}
-                    name="business_type"
-                    render={({ field }) => (
-                      <FormItem className="space-y-3">
-                        <FormLabel>What type of business do you run?</FormLabel>
-                        <FormControl>
-                          <RadioGroup
-                            onValueChange={field.onChange}
-                            value={field.value}
-                            className="grid grid-cols-2 sm:grid-cols-3 gap-3"
-                          >
-                            {business_type_options.map((option) => {
-                              const value = optionToValue(option);
-                              return (
-                                <FormItem
-                                  key={value}
-                                  className="flex items-center space-x-1 space-y-0"
-                                >
-                                  <FormControl>
-                                    <RadioGroupItem
-                                      value={value}
-                                      id={`business-${value}`}
-                                      className="sr-only"
-                                    />
-                                  </FormControl>
-                                  <FormLabel
-                                    htmlFor={`business-${value}`}
-                                    className={`border rounded-lg p-3 w-full flex items-center gap-2 cursor-pointer transition-all ${field.value === value
-                                      ? "border-primary bg-primary/10"
-                                      : "border-border hover:border-muted-foreground"
-                                      }`}
-                                  >
-                                    <div
-                                      className={`size-4 rounded-full border ${field.value === value
-                                        ? "border-4 border-primary"
-                                        : "border border-muted-foreground"
-                                        }`}
-                                    ></div>
-                                    <span>{option}</span>
-                                  </FormLabel>
-                                </FormItem>
-                              );
-                            })}
-                          </RadioGroup>
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {watchedBusinessType === "other" && (
-                    <FormField
-                      control={step2Form.control}
-                      name="other_business_type"
-                      render={({ field }) => (
-                        <FormItem>
                           <FormLabel>
-                            Tell us your business type
+                            Which platform should we know about?
                           </FormLabel>
                           <FormControl>
                             <Input {...field} />
@@ -758,17 +1190,100 @@ export default function OnboardingPage() {
                         </FormItem>
                       )}
                     />
-                  )}
+                  ) : null}
+
+                  <StepButtons onBack={handleBack} isLoading={isLoading} />
+                </form>
+              </Form>
+            </div>
+          ) : null}
+
+          {activeStep === 4 ? (
+            <div className="rounded-xl border border-border p-6 shadow-sm">
+              <Form {...step2Form}>
+                <form
+                  onSubmit={step2Form.handleSubmit(handleStep2Submit)}
+                  className="space-y-6"
+                >
+                  <h2 className="font-heading text-xl font-semibold">
+                    Business And Goals
+                  </h2>
+
+                  <FormField
+                    control={step2Form.control}
+                    name="business_type"
+                    render={({ field }) => (
+                      <FormItem className="space-y-3">
+                        <FormLabel>
+                          What best describes your business?
+                        </FormLabel>
+                        <FormControl>
+                          <RadioGroup
+                            onValueChange={field.onChange}
+                            value={field.value}
+                            className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+                          >
+                            {business_type_options.map((option) => (
+                              <FormItem
+                                key={option}
+                                className="flex items-center space-x-1 space-y-0"
+                              >
+                                <FormControl>
+                                  <RadioGroupItem
+                                    value={option}
+                                    id={`business-${option}`}
+                                    className="sr-only"
+                                  />
+                                </FormControl>
+                                <FormLabel
+                                  htmlFor={`business-${option}`}
+                                  className={`flex w-full cursor-pointer items-center justify-center rounded-lg border p-3 text-center transition-all ${
+                                    field.value === option
+                                      ? "border-primary bg-primary/10"
+                                      : "border-border hover:border-muted-foreground"
+                                  }`}
+                                >
+                                  {option}
+                                </FormLabel>
+                              </FormItem>
+                            ))}
+                          </RadioGroup>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {watchedBusinessType === "Other" ? (
+                    <FormField
+                      control={step2Form.control}
+                      name="other_business_type"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Tell us about your business type
+                          </FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  ) : null}
 
                   <FormField
                     control={step2Form.control}
                     name="pilot_goal"
                     render={({ field }) => (
                       <FormItem className="space-y-3">
-                        <FormLabel>What are your goals with Pilot?</FormLabel>
-                        <div className="space-y-2">
+                        <FormLabel>
+                          What do you want Pilot to help with?
+                        </FormLabel>
+                        <div className="flex flex-col gap-2">
                           {pilot_goal_options.map((option) => {
                             const value = optionToValue(option);
+
                             return (
                               <FormItem
                                 key={value}
@@ -781,8 +1296,9 @@ export default function OnboardingPage() {
                                       const updatedValue = checked
                                         ? [...field.value, value]
                                         : field.value.filter(
-                                          (val) => val !== value
-                                        );
+                                            (currentValue) =>
+                                              currentValue !== value,
+                                          );
                                       field.onChange(updatedValue);
                                     }}
                                   />
@@ -804,14 +1320,17 @@ export default function OnboardingPage() {
                     name="current_tracking"
                     render={({ field }) => (
                       <FormItem className="space-y-3">
-                        <FormLabel>How do you currently track leads?</FormLabel>
-                        <div className="space-y-2">
+                        <FormLabel>
+                          How are you tracking leads right now?
+                        </FormLabel>
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                           {current_tracking_options.map((option) => {
                             const value = optionToValue(option);
+
                             return (
                               <FormItem
                                 key={value}
-                                className="flex flex-row items-start space-x-3 space-y-0"
+                                className="flex flex-row items-start space-x-3 space-y-0 rounded-lg border p-3"
                               >
                                 <FormControl>
                                   <Checkbox
@@ -820,8 +1339,9 @@ export default function OnboardingPage() {
                                       const updatedValue = checked
                                         ? [...field.value, value]
                                         : field.value.filter(
-                                          (val) => val !== value
-                                        );
+                                            (currentValue) =>
+                                              currentValue !== value,
+                                          );
                                       field.onChange(updatedValue);
                                     }}
                                   />
@@ -838,15 +1358,13 @@ export default function OnboardingPage() {
                     )}
                   />
 
-                  {watchedCurrentTracking?.includes("other") && (
+                  {watchedCurrentTracking?.includes("other") ? (
                     <FormField
                       control={step2Form.control}
                       name="other_tracking"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>
-                            Tell us how you track leads
-                          </FormLabel>
+                          <FormLabel>What are you using today?</FormLabel>
                           <FormControl>
                             <Input {...field} />
                           </FormControl>
@@ -854,19 +1372,33 @@ export default function OnboardingPage() {
                         </FormItem>
                       )}
                     />
-                  )}
+                  ) : null}
 
                   <StepButtons
-                    isLoading={isLoading}
                     onBack={handleBack}
-                    submitLabel="Finish Setup"
+                    submitLabel="Continue To Sidekick"
+                    isLoading={isLoading}
                   />
                 </form>
               </Form>
-            )}
-          </div>
+            </div>
+          ) : null}
         </CardContent>
       </Card>
     </section>
+  );
+}
+
+export default function OnboardingPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">
+          <p>Loading your setup...</p>
+        </div>
+      }
+    >
+      <OnboardingPageContent />
+    </Suspense>
   );
 }

--- a/apps/app/src/app/(onboarding)/onboarding/page.tsx
+++ b/apps/app/src/app/(onboarding)/onboarding/page.tsx
@@ -1214,7 +1214,7 @@ function OnboardingPageContent() {
                               >
                                 <FormControl>
                                   <RadioGroupItem
-                                    value={option}
+                                    value={optionToValue(option)}
                                     id={`business-${option}`}
                                     className="sr-only"
                                   />
@@ -1222,7 +1222,7 @@ function OnboardingPageContent() {
                                 <FormLabel
                                   htmlFor={`business-${option}`}
                                   className={`flex w-full cursor-pointer items-center justify-center rounded-lg border p-3 text-center transition-all ${
-                                    field.value === option
+                                    field.value === optionToValue(option)
                                       ? "border-primary bg-primary/10"
                                       : "border-border hover:border-muted-foreground"
                                   }`}
@@ -1238,7 +1238,7 @@ function OnboardingPageContent() {
                     )}
                   />
 
-                  {watchedBusinessType === "Other" ? (
+                  {watchedBusinessType === "other" ? (
                     <FormField
                       control={step2Form.control}
                       name="other_business_type"

--- a/apps/app/src/app/(onboarding)/sidekick-onboarding/page.tsx
+++ b/apps/app/src/app/(onboarding)/sidekick-onboarding/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, useWatch, UseFormReturn } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
 import { Card, CardContent } from "@pilot/ui/components/card";
@@ -50,7 +50,9 @@ import {
 } from "@/actions/sidekick/onboarding";
 
 const step0Schema = z.object({
-  primaryOfferUrl: z.string().url({ message: "That doesn't look like a valid URL" }),
+  primaryOfferUrl: z
+    .string()
+    .url({ message: "That doesn't look like a valid URL" }),
   calendarLink: z
     .string()
     .url({ message: "That doesn't look like a valid URL" })
@@ -65,18 +67,20 @@ const step0Schema = z.object({
 
 const step1Schema = z.object({
   offerName: z.string().min(1, { message: "What should we call this offer?" }),
-  offerContent: z.string().min(1, { message: "Tell us what this offer includes" }),
+  offerContent: z
+    .string()
+    .min(1, { message: "Tell us what this offer includes" }),
   offerValue: z.string().optional(),
 });
 
 const step2Schema = z.object({
-  sellDescription: z
-    .string()
-    .min(1, { message: "Tell us what you sell" }),
+  sellDescription: z.string().min(1, { message: "Tell us what you sell" }),
 });
 
 const step3Schema = z.object({
-  question: z.string().min(1, { message: "What question do people always ask?" }),
+  question: z
+    .string()
+    .min(1, { message: "What question do people always ask?" }),
   answer: z.string().optional(),
 });
 
@@ -95,80 +99,13 @@ type step4FormValues = z.infer<typeof step4Schema>;
 type OfferItem = { id?: string; name: string; content: string; value?: number };
 type FaqItem = { id?: string; question: string; answer?: string };
 
-async function checkSidekickStatusAction(
-  router: { replace: (url: string) => void },
-  setIsInitializing: (v: boolean) => void
-) {
-  try {
-    setIsInitializing(true);
-    const status = await checkSidekickOnboardingStatus();
-    if (status.sidekick_onboarding_complete) {
-      router.replace("/");
-    }
-  } catch (error) {
-    console.error("Error checking sidekick onboarding status:", error);
-  } finally {
-    setIsInitializing(false);
-  }
-}
-
-async function fetchOfferLinksAction(
-  step0Form: UseFormReturn<step0FormValues>,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  setIsInitializing: (v: boolean) => void
-) {
-  try {
-    setIsInitializing(true);
-    const result = await getSidekickOfferLinks();
-
-    if (result.success && result.data) {
-      step0Form.setValue("primaryOfferUrl", result.data.primaryOfferUrl || "");
-      step0Form.setValue("calendarLink", result.data.calendarLink || "");
-      step0Form.setValue("additionalInfoUrl", result.data.additionalInfoUrl || "");
-
-      if (result.data.primaryOfferUrl) {
-        setStepValidationState((prevState) => ({ ...prevState, 0: true }));
-      }
-    }
-  } catch (error) {
-    console.error("Error fetching offer links:", error);
-  } finally {
-    setIsInitializing(false);
-  }
-}
-
-async function fetchOffersAction(
-  setOffers: React.Dispatch<React.SetStateAction<OfferItem[]>>,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  setIsInitializing: (v: boolean) => void
-) {
-  try {
-    setIsInitializing(true);
-    const result = await getSidekickOffers();
-
-    if (result.success && result.data && result.data.length > 0) {
-      setOffers(
-        result.data.map((offer) => ({
-          id: offer.id,
-          name: offer.name,
-          content: offer.content,
-          value: offer.value || undefined,
-        }))
-      );
-      setStepValidationState((prevState) => ({ ...prevState, 1: true }));
-    }
-  } catch (error) {
-    console.error("Error fetching offers:", error);
-  } finally {
-    setIsInitializing(false);
-  }
-}
-
 async function submitSidekickStep0Action(
   values: step0FormValues,
   setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  onSuccess: () => void
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  onSuccess: () => void,
 ) {
   try {
     setIsLoading(true);
@@ -208,7 +145,9 @@ async function submitSidekickStep1Action(
   step1Form: { reset: (values: step1FormValues) => void },
   setOffers: React.Dispatch<React.SetStateAction<OfferItem[]>>,
   setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
 ) {
   try {
     setIsLoading(true);
@@ -247,8 +186,10 @@ async function submitSidekickStep1Action(
 async function submitSidekickStep2Action(
   values: step2FormValues,
   setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  onSuccess: () => void
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  onSuccess: () => void,
 ) {
   try {
     setIsLoading(true);
@@ -262,7 +203,7 @@ async function submitSidekickStep2Action(
       return;
     }
 
-    setStepValidationState((prevState) => ({ ...prevState, 2: true }));
+    setStepValidationState((prevState) => ({ ...prevState, 1: true }));
     onSuccess();
     toast.success("Saved. Almost done.");
   } catch (error) {
@@ -279,13 +220,15 @@ async function submitSidekickStep3Action(
   step3Form: { reset: (values: step3FormValues) => void },
   setFaqs: React.Dispatch<React.SetStateAction<FaqItem[]>>,
   setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
 ) {
   try {
     setIsLoading(true);
 
     const isDuplicate = currentFaqs.some(
-      (faq) => faq.question.toLowerCase() === values.question.toLowerCase()
+      (faq) => faq.question.toLowerCase() === values.question.toLowerCase(),
     );
 
     if (isDuplicate) {
@@ -302,9 +245,12 @@ async function submitSidekickStep3Action(
       return;
     }
 
-    setFaqs([...currentFaqs, { question: values.question, answer: values.answer }]);
+    setFaqs([
+      ...currentFaqs,
+      { question: values.question, answer: values.answer },
+    ]);
     step3Form.reset({ question: "", answer: "" });
-    setStepValidationState((prevState) => ({ ...prevState, 3: true }));
+    setStepValidationState((prevState) => ({ ...prevState, 2: true }));
     toast.success("FAQ saved successfully!");
   } catch (error) {
     console.error("Error submitting step 3:", error);
@@ -317,8 +263,10 @@ async function submitSidekickStep3Action(
 async function submitSidekickStep4Action(
   values: step4FormValues,
   setIsLoading: (v: boolean) => void,
-  setStepValidationState: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
-  router: { push: (url: string) => void }
+  setStepValidationState: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >,
+  router: { push: (url: string) => void },
 ) {
   try {
     setIsLoading(true);
@@ -368,7 +316,7 @@ async function submitSidekickStep4Action(
       return;
     }
 
-    setStepValidationState((prevState) => ({ ...prevState, 4: true }));
+    setStepValidationState((prevState) => ({ ...prevState, 3: true }));
     toast.success("Sidekick is ready.");
     router.push("/");
   } catch (error) {
@@ -383,7 +331,7 @@ async function deleteFaqAction(
   faqId: string,
   currentFaqs: FaqItem[],
   setFaqs: React.Dispatch<React.SetStateAction<FaqItem[]>>,
-  setIsLoading: (v: boolean) => void
+  setIsLoading: (v: boolean) => void,
 ) {
   try {
     setIsLoading(true);
@@ -407,7 +355,7 @@ async function deleteOfferAction(
   index: number,
   currentOffers: OfferItem[],
   setOffers: React.Dispatch<React.SetStateAction<OfferItem[]>>,
-  setIsLoading: (v: boolean) => void
+  setIsLoading: (v: boolean) => void,
 ) {
   try {
     setIsLoading(true);
@@ -433,6 +381,7 @@ export default function SidekickOnboardingPage() {
   const [activeStep, setActiveStep] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
+  const [hasStoredMainOffering, setHasStoredMainOffering] = useState(false);
   const [offers, setOffers] = useState<
     Array<{ id?: string; name: string; content: string; value?: number }>
   >([]);
@@ -443,7 +392,6 @@ export default function SidekickOnboardingPage() {
     1: false,
     2: false,
     3: false,
-    4: false,
   });
 
   const [faqs, setFaqs] = useState<
@@ -493,109 +441,213 @@ export default function SidekickOnboardingPage() {
   });
 
   useEffect(() => {
-    checkSidekickStatusAction(router, setIsInitializing);
-  }, [router]);
+    let isMounted = true;
 
-  useEffect(() => {
-    fetchOfferLinksAction(step0Form, setStepValidationState, setIsInitializing);
-  }, []);
+    async function initializeSidekickOnboarding() {
+      setIsInitializing(true);
 
-  useEffect(() => {
-    fetchOffersAction(setOffers, setStepValidationState, setIsInitializing);
-  }, []);
+      const status = await checkSidekickOnboardingStatus().catch((error) => {
+        console.error("Error checking sidekick onboarding status:", error);
+        return null;
+      });
 
-  useEffect(() => {
-    async function fetchMainOffering() {
-      try {
-        const result = await getSidekickMainOffering();
-
-        if (result.success) {
-          if (result.data) {
-            step2Form.setValue("sellDescription", result.data);
-            setStepValidationState((prevState) => ({ ...prevState, 2: true }));
-          }
+      if (!status) {
+        if (isMounted) {
+          setIsInitializing(false);
         }
-      } catch (error) {
-        console.error("Error fetching main offering:", error);
-      }
-    }
-
-    fetchMainOffering();
-  }, []);
-
-  useEffect(() => {
-    async function fetchFaqs() {
-      const result = await getSidekickFaqs().catch((error) => {
-        console.error("Error fetching FAQs:", error);
-        return null;
-      });
-
-      if (!result || !result.success || !result.data || result.data.length === 0) {
         return;
       }
 
-      setFaqs(
-        result.data.map((faq) => ({
-          id: faq.id,
-          question: faq.question,
-          answer: faq.answer || undefined,
-        }))
-      );
-      setStepValidationState((prevState) => ({ ...prevState, 3: true }));
-    }
-
-    fetchFaqs();
-  }, []);
-
-  useEffect(() => {
-    async function fetchToneProfile() {
-      const result = await getSidekickToneProfile().catch((error) => {
-        console.error("Error fetching tone profile:", error);
-        return null;
-      });
-
-      if (!result || !result.success || !result.data) {
+      if (status.sidekick_onboarding_complete) {
+        router.replace("/");
+        if (isMounted) {
+          setIsInitializing(false);
+        }
         return;
       }
 
-      step4Form.setValue("toneType", result.data.toneType || "");
-      step4Form.setValue("customTone", result.data.customTone || "");
-      step4Form.setValue("sampleMessages", result.data.sampleMessages || "");
+      const [
+        offerLinksResult,
+        offersResult,
+        mainOfferingResult,
+        faqsResult,
+        toneProfileResult,
+      ] = await Promise.all([
+        getSidekickOfferLinks().catch((error) => {
+          console.error("Error fetching offer links:", error);
+          return null;
+        }),
+        getSidekickOffers().catch((error) => {
+          console.error("Error fetching offers:", error);
+          return null;
+        }),
+        getSidekickMainOffering().catch((error) => {
+          console.error("Error fetching main offering:", error);
+          return null;
+        }),
+        getSidekickFaqs().catch((error) => {
+          console.error("Error fetching FAQs:", error);
+          return null;
+        }),
+        getSidekickToneProfile().catch((error) => {
+          console.error("Error fetching tone profile:", error);
+          return null;
+        }),
+      ]);
 
-      if (result.data.toneType) {
-        setStepValidationState((prevState) => ({ ...prevState, 4: true }));
+      if (!isMounted) {
+        return;
       }
+
+      if (offerLinksResult?.success && offerLinksResult.data) {
+        step0Form.setValue(
+          "primaryOfferUrl",
+          offerLinksResult.data.primaryOfferUrl || "",
+        );
+        step0Form.setValue(
+          "calendarLink",
+          offerLinksResult.data.calendarLink || "",
+        );
+        step0Form.setValue(
+          "additionalInfoUrl",
+          offerLinksResult.data.additionalInfoUrl || "",
+        );
+      }
+
+      const initialOffers =
+        offersResult?.success && offersResult.data
+          ? offersResult.data.map((offer) => ({
+              id: offer.id,
+              name: offer.name,
+              content: offer.content,
+              value: offer.value || undefined,
+            }))
+          : [];
+      setOffers(initialOffers);
+
+      const storedMainOffering =
+        mainOfferingResult?.success &&
+        typeof mainOfferingResult.data === "string"
+          ? mainOfferingResult.data
+          : null;
+      if (storedMainOffering) {
+        step2Form.setValue("sellDescription", storedMainOffering);
+      }
+      setHasStoredMainOffering(!!storedMainOffering);
+
+      const initialFaqs =
+        faqsResult?.success && faqsResult.data
+          ? faqsResult.data.map((faq) => ({
+              id: faq.id,
+              question: faq.question,
+              answer: faq.answer || undefined,
+            }))
+          : [];
+      setFaqs(initialFaqs);
+
+      if (toneProfileResult?.success && toneProfileResult.data) {
+        step4Form.setValue("toneType", toneProfileResult.data.toneType || "");
+        step4Form.setValue(
+          "customTone",
+          toneProfileResult.data.customTone || "",
+        );
+        step4Form.setValue(
+          "sampleMessages",
+          toneProfileResult.data.sampleMessages || "",
+        );
+      }
+
+      setStepValidationState({
+        0:
+          !!offerLinksResult?.success &&
+          !!offerLinksResult.data?.primaryOfferUrl,
+        1: initialOffers.length > 0 && !!storedMainOffering,
+        2: initialFaqs.length > 0,
+        3: !!toneProfileResult?.success && !!toneProfileResult.data?.toneType,
+      });
+      setIsInitializing(false);
     }
 
-    fetchToneProfile();
-  }, []);
+    initializeSidekickOnboarding();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [router, step0Form, step2Form, step4Form]);
 
   const handleStep0Submit = () =>
-    submitSidekickStep0Action(step0Form.getValues(), setIsLoading, setStepValidationState, handleNext);
+    submitSidekickStep0Action(
+      step0Form.getValues(),
+      setIsLoading,
+      setStepValidationState,
+      handleNext,
+    );
 
   const handleStep1Submit = (values: step1FormValues) =>
-    submitSidekickStep1Action(values, offers, step1Form, setOffers, setIsLoading, setStepValidationState);
+    submitSidekickStep1Action(
+      values,
+      offers,
+      step1Form,
+      setOffers,
+      setIsLoading,
+      setStepValidationState,
+    );
 
   const handleStep2Submit = (values: step2FormValues) =>
-    submitSidekickStep2Action(values, setIsLoading, setStepValidationState, handleNext);
+    submitSidekickStep2Action(
+      values,
+      setIsLoading,
+      setStepValidationState,
+      () => {
+        setHasStoredMainOffering(true);
+        handleNext();
+      },
+    );
 
   const handleStep3Submit = (values: step3FormValues) =>
-    submitSidekickStep3Action(values, faqs, step3Form, setFaqs, setIsLoading, setStepValidationState);
+    submitSidekickStep3Action(
+      values,
+      faqs,
+      step3Form,
+      setFaqs,
+      setIsLoading,
+      setStepValidationState,
+    );
 
   const handleStep4Submit = (values: step4FormValues) =>
-    submitSidekickStep4Action(values, setIsLoading, setStepValidationState, router);
+    submitSidekickStep4Action(
+      values,
+      setIsLoading,
+      setStepValidationState,
+      router,
+    );
 
   const handleDeleteFaq = (faqId: string) =>
     deleteFaqAction(faqId, faqs, setFaqs, setIsLoading);
 
-  const watchedToneType = useWatch({ control: step4Form.control, name: "toneType" });
+  const watchedSellDescription = useWatch({
+    control: step2Form.control,
+    name: "sellDescription",
+  });
+  const watchedToneType = useWatch({
+    control: step4Form.control,
+    name: "toneType",
+  });
 
   const handleBack = () => {
-    setActiveStep(prev => prev - 1);
+    setActiveStep((prev) => prev - 1);
   };
 
   const handleNext = () => {
-    setActiveStep(prev => prev + 1);
+    setActiveStep((prev) => prev + 1);
+  };
+
+  const isStepValid = (step: number) => {
+    if (step === 1) {
+      return offers.length > 0 && hasStoredMainOffering;
+    }
+
+    return stepValidationState[step];
   };
 
   if (isInitializing) {
@@ -619,7 +671,7 @@ export default function SidekickOnboardingPage() {
               }
 
               if (newStep === activeStep + 1) {
-                const isValid = stepValidationState[activeStep];
+                const isValid = isStepValid(activeStep);
                 if (isValid) {
                   setActiveStep(newStep);
                 }
@@ -633,11 +685,11 @@ export default function SidekickOnboardingPage() {
                 step={step.id}
                 disabled={
                   step.id > activeStep + 1 ||
-                  (step.id > activeStep && !stepValidationState[activeStep])
+                  (step.id > activeStep && !isStepValid(activeStep))
                 }
                 completed={activeStep > step.id}
                 loading={isLoading && step.id === activeStep}
-                className="relative flex-1 flex-col!"
+                className="relative flex-1 !flex-col"
               >
                 <StepperTrigger className="flex-col gap-3">
                   <StepperIndicator />
@@ -659,7 +711,9 @@ export default function SidekickOnboardingPage() {
                   onSubmit={step0Form.handleSubmit(handleStep0Submit)}
                   className="space-y-6"
                 >
-                  <h2 className="text-xl font-semibold font-heading">Offer Links</h2>
+                  <h2 className="text-xl font-semibold font-heading">
+                    Offer Links
+                  </h2>
 
                   <p className="text-muted-foreground">
                     Add links so Sidekick can learn your offer details.
@@ -723,167 +777,185 @@ export default function SidekickOnboardingPage() {
             )}
 
             {activeStep === 1 && (
-              <Form {...step1Form}>
-                <form
-                  onSubmit={step1Form.handleSubmit(handleStep1Submit)}
-                  className="space-y-6"
-                >
-                  <h2 className="text-xl font-semibold font-heading">Offers</h2>
-
+              <div className="space-y-6">
+                <div>
+                  <h2 className="text-xl font-semibold font-heading">
+                    What You Sell
+                  </h2>
                   <p className="text-muted-foreground">
-                    Add your offers so Sidekick can answer clearly and score leads better.
+                    Add your offers and explain the main offer so Sidekick can
+                    reply with the right details.
                   </p>
+                </div>
 
-                  {offers.length > 0 && (
-                    <div className="border rounded-lg p-4 space-y-3">
-                      <h3 className="font-medium">Your Offers</h3>
-                      <div className="space-y-2">
-                        {offers.map((offer, index) => (
-                          <div
-                            key={index}
-                            className="border rounded p-3 flex justify-between items-center"
-                          >
-                            <div>
-                              <p className="font-medium">{offer.name}</p>
-                              <p className="text-sm text-muted-foreground truncate max-w-md">
-                                {offer.content}
-                              </p>
-                            </div>
-                            <div className="flex items-center gap-3">
-                              {offer.value && (
-                                <p className="font-medium">${offer.value}</p>
-                              )}
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                                onClick={() => deleteOfferAction(offer.id, index, offers, setOffers, setIsLoading)}
-                              >
-                                Delete
-                              </Button>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  <FormField
-                    control={step1Form.control}
-                    name="offerName"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Offer Name</FormLabel>
-                        <FormControl>
-                          <Input placeholder="e.g., Basic Package" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={step1Form.control}
-                    name="offerContent"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Offer Description</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            placeholder="Brief description of what's included"
-                            {...field}
-                            rows={3}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={step1Form.control}
-                    name="offerValue"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Value ($)</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="number"
-                            placeholder="e.g., 997"
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <div className="flex justify-between">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={handleBack}
-                    >
-                      Back
-                    </Button>
-                    <div className="space-x-2">
-                      {offers.length > 0 && (
-                        <Button
-                          type="button"
-                          variant="default"
-                          onClick={() => handleNext()}
+                {offers.length > 0 && (
+                  <div className="border rounded-lg p-4 space-y-3">
+                    <h3 className="font-medium">Your Offers</h3>
+                    <div className="space-y-2">
+                      {offers.map((offer, index) => (
+                        <div
+                          key={offer.id || index}
+                          className="border rounded p-3 flex justify-between items-center"
                         >
-                          Next
-                        </Button>
+                          <div>
+                            <p className="font-medium">{offer.name}</p>
+                            <p className="text-sm text-muted-foreground truncate max-w-md">
+                              {offer.content}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            {offer.value ? (
+                              <p className="font-medium">${offer.value}</p>
+                            ) : null}
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                              onClick={() =>
+                                deleteOfferAction(
+                                  offer.id,
+                                  index,
+                                  offers,
+                                  setOffers,
+                                  setIsLoading,
+                                )
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <Form {...step1Form}>
+                  <form
+                    onSubmit={step1Form.handleSubmit(handleStep1Submit)}
+                    className="space-y-4 rounded-lg border p-4"
+                  >
+                    <div>
+                      <h3 className="font-medium">Add an offer</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Keep this tight. One offer is enough to continue.
+                      </p>
+                    </div>
+
+                    <FormField
+                      control={step1Form.control}
+                      name="offerName"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Offer Name</FormLabel>
+                          <FormControl>
+                            <Input
+                              placeholder="e.g., Basic Package"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
                       )}
+                    />
+
+                    <FormField
+                      control={step1Form.control}
+                      name="offerContent"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Offer Description</FormLabel>
+                          <FormControl>
+                            <Textarea
+                              placeholder="Brief description of what's included"
+                              {...field}
+                              rows={3}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={step1Form.control}
+                      name="offerValue"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Value ($)</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              placeholder="e.g., 997"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="flex justify-end">
                       <Button type="submit" disabled={isLoading}>
                         {isLoading ? "Adding..." : "Add Offer"}
                       </Button>
                     </div>
-                  </div>
-                </form>
-              </Form>
+                  </form>
+                </Form>
+
+                <Form {...step2Form}>
+                  <form
+                    onSubmit={step2Form.handleSubmit(handleStep2Submit)}
+                    className="space-y-6"
+                  >
+                    <FormField
+                      control={step2Form.control}
+                      name="sellDescription"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Your Offering</FormLabel>
+                          <FormControl>
+                            <Textarea
+                              placeholder="e.g., 8-week cohort-based course for SaaS founders on monetization"
+                              {...field}
+                              rows={4}
+                            />
+                          </FormControl>
+                          <FormDescription>
+                            More detail here means better replies later.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="flex justify-between">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleBack}
+                        disabled={isLoading}
+                      >
+                        Back
+                      </Button>
+                      <Button
+                        type="submit"
+                        disabled={
+                          isLoading ||
+                          offers.length === 0 ||
+                          !watchedSellDescription?.trim()
+                        }
+                      >
+                        Next
+                      </Button>
+                    </div>
+                  </form>
+                </Form>
+              </div>
             )}
 
             {activeStep === 2 && (
-              <Form {...step2Form}>
-                <form
-                  onSubmit={step2Form.handleSubmit(handleStep2Submit)}
-                  className="space-y-6"
-                >
-                  <h2 className="text-xl font-semibold font-heading">What You Sell</h2>
-
-                  <p className="text-muted-foreground">
-                    Explain your main offer so Sidekick can reply with the right details.
-                  </p>
-
-                  <FormField
-                    control={step2Form.control}
-                    name="sellDescription"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Your Offering</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            placeholder="e.g., 8-week cohort-based course for SaaS founders on monetization"
-                            {...field}
-                            rows={4}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          More detail here means better replies later.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <StepButtons onBack={handleBack} isLoading={isLoading} />
-                </form>
-              </Form>
-            )}
-
-            {activeStep === 3 && (
               <div className="space-y-6">
                 <div className="mb-4">
                   <h3 className="text-lg font-medium">
@@ -995,7 +1067,7 @@ export default function SidekickOnboardingPage() {
               </div>
             )}
 
-            {activeStep === 4 && (
+            {activeStep === 3 && (
               <Form {...step4Form}>
                 <form
                   onSubmit={step4Form.handleSubmit(handleStep4Submit)}
@@ -1035,16 +1107,18 @@ export default function SidekickOnboardingPage() {
                                 </FormControl>
                                 <FormLabel
                                   htmlFor={`tone-${option}`}
-                                  className={`border rounded-lg p-3 w-full flex items-center gap-2 cursor-pointer transition-all ${field.value === option
-                                    ? "border-primary bg-primary/10"
-                                    : "border-border hover:border-muted-foreground"
-                                    }`}
+                                  className={`border rounded-lg p-3 w-full flex items-center gap-2 cursor-pointer transition-all ${
+                                    field.value === option
+                                      ? "border-primary bg-primary/10"
+                                      : "border-border hover:border-muted-foreground"
+                                  }`}
                                 >
                                   <div
-                                    className={`size-4 rounded-full border ${field.value === option
-                                      ? "border-4 border-primary"
-                                      : "border border-muted-foreground"
-                                      }`}
+                                    className={`size-4 rounded-full border ${
+                                      field.value === option
+                                        ? "border-4 border-primary"
+                                        : "border border-muted-foreground"
+                                    }`}
                                   ></div>
                                   <span>{option}</span>
                                 </FormLabel>

--- a/apps/app/src/app/api/auth/instagram/callback/route.ts
+++ b/apps/app/src/app/api/auth/instagram/callback/route.ts
@@ -6,43 +6,22 @@ import {
   exchangeLongLivedInstagramToken,
   fetchInstagramProfile,
 } from "@pilot/instagram";
+import {
+  getInstagramAppBaseUrl,
+  getInstagramCallbackUrl,
+  normalizeInstagramReturnTo,
+} from "@/lib/instagram-auth";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_CLIENT_SECRET = process.env.INSTAGRAM_CLIENT_SECRET;
 const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
-const APP_URL =
-  process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
-
-function normalizeReturnTo(value: string | null) {
-  if (
-    !value ||
-    !value.startsWith("/") ||
-    value.startsWith("//") ||
-    value.includes("\\")
-  ) {
-    return "/settings";
-  }
-
-  try {
-    // Placeholder origin used only to parse a relative in-app return path safely.
-    const url = new URL(value, "http://localhost.invalid");
-    if (url.origin !== "http://localhost.invalid") {
-      return "/settings";
-    }
-
-    return `${url.pathname}${url.search}${url.hash}`;
-  } catch {
-    return "/settings";
-  }
-}
 
 function buildRedirectUrl(
   request: Request,
   returnTo: string,
   params: Record<string, string>,
 ) {
-  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
-  const url = new URL(returnTo, baseUrl);
+  const url = new URL(returnTo, getInstagramAppBaseUrl(request));
 
   Object.entries(params).forEach(([key, value]) => {
     url.searchParams.set(key, value);
@@ -51,16 +30,11 @@ function buildRedirectUrl(
   return url.toString();
 }
 
-function getInstagramCallbackUrl(request: Request) {
-  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
-  return new URL("/api/auth/instagram/callback", baseUrl).toString();
-}
-
 export async function GET(request: Request) {
   const redirectUri = getInstagramCallbackUrl(request);
   const { searchParams } = new URL(request.url);
   const cookieStore = await cookies();
-  const returnTo = normalizeReturnTo(
+  const returnTo = normalizeInstagramReturnTo(
     cookieStore.get(INSTAGRAM_RETURN_TO_COOKIE)?.value ?? null,
   );
   cookieStore.delete(INSTAGRAM_RETURN_TO_COOKIE);

--- a/apps/app/src/app/api/auth/instagram/callback/route.ts
+++ b/apps/app/src/app/api/auth/instagram/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { saveInstagramConnection } from "@/actions/instagram";
 import {
   exchangeCodeForAccessToken,
@@ -8,29 +9,78 @@ import {
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_CLIENT_SECRET = process.env.INSTAGRAM_CLIENT_SECRET;
+const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
+
+function normalizeReturnTo(value: string | null) {
+  if (
+    !value ||
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\")
+  ) {
+    return "/settings";
+  }
+
+  try {
+    const url = new URL(value, "http://pilot.local");
+    if (url.origin !== "http://pilot.local") {
+      return "/settings";
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/settings";
+  }
+}
+
+function buildRedirectUrl(
+  request: Request,
+  returnTo: string,
+  params: Record<string, string>,
+) {
+  const url = new URL(returnTo, process.env.NEXT_PUBLIC_APP_URL ?? request.url);
+
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  return url.toString();
+}
 
 export async function GET(request: Request) {
-  const redirectUri = new URL("/api/auth/instagram/callback", request.url).toString();
+  const redirectUri = new URL(
+    "/api/auth/instagram/callback",
+    request.url,
+  ).toString();
   const { searchParams } = new URL(request.url);
+  const cookieStore = await cookies();
+  const returnTo = normalizeReturnTo(
+    cookieStore.get(INSTAGRAM_RETURN_TO_COOKIE)?.value ?? null,
+  );
+  cookieStore.delete(INSTAGRAM_RETURN_TO_COOKIE);
   const code = getRawQueryParam(request.url, "code");
   const error = searchParams.get("error");
 
   if (error) {
     console.error("Instagram auth error from redirect:", error);
-    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_APP_URL}/settings?error=${error}`);
+    return NextResponse.redirect(
+      buildRedirectUrl(request, returnTo, { error }),
+    );
   }
 
   if (!code) {
     console.error("No code provided in Instagram callback");
-    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_APP_URL}/settings?error=no_code`);
+    return NextResponse.redirect(
+      buildRedirectUrl(request, returnTo, { error: "no_code" }),
+    );
   }
 
   try {
-    console.log("Exchanging code for access token with redirect URI:", redirectUri);
-    const {
-      accessToken,
-      appScopedUserId,
-    } = await exchangeCodeForAccessToken({
+    console.log(
+      "Exchanging code for access token with redirect URI:",
+      redirectUri,
+    );
+    const { accessToken, appScopedUserId } = await exchangeCodeForAccessToken({
       clientId: INSTAGRAM_CLIENT_ID!,
       clientSecret: INSTAGRAM_CLIENT_SECRET!,
       redirectUri,
@@ -38,13 +88,11 @@ export async function GET(request: Request) {
     });
 
     console.log("Getting user profile with IG ID:", appScopedUserId);
-    const {
-      username,
-      user_id: professionalUserId,
-    } = await fetchInstagramProfile({
-      accessToken,
-      igUserId: appScopedUserId,
-    });
+    const { username, user_id: professionalUserId } =
+      await fetchInstagramProfile({
+        accessToken,
+        igUserId: appScopedUserId,
+      });
 
     if (!professionalUserId) {
       throw new Error("Instagram profile response did not return user_id");
@@ -60,13 +108,11 @@ export async function GET(request: Request) {
       normalizedAppScopedUserId,
     );
 
-    const {
-      accessToken: longLivedToken,
-      expiresIn: expires_in,
-    } = await exchangeLongLivedInstagramToken({
-      clientSecret: INSTAGRAM_CLIENT_SECRET!,
-      accessToken,
-    });
+    const { accessToken: longLivedToken, expiresIn: expires_in } =
+      await exchangeLongLivedInstagramToken({
+        clientSecret: INSTAGRAM_CLIENT_SECRET!,
+        accessToken,
+      });
 
     const result = await saveInstagramConnection({
       instagramUserId: normalizedProfessionalUserId,
@@ -81,11 +127,13 @@ export async function GET(request: Request) {
     }
 
     console.log("Instagram connection saved to database");
-    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_APP_URL}/settings?success=instagram_connected`);
+    return NextResponse.redirect(
+      buildRedirectUrl(request, returnTo, { success: "instagram_connected" }),
+    );
   } catch (error) {
     console.error("Instagram auth error:", error);
     return NextResponse.redirect(
-      `${process.env.NEXT_PUBLIC_APP_URL}/settings?error=auth_failed`
+      buildRedirectUrl(request, returnTo, { error: "auth_failed" }),
     );
   }
 }

--- a/apps/app/src/app/api/auth/instagram/callback/route.ts
+++ b/apps/app/src/app/api/auth/instagram/callback/route.ts
@@ -10,6 +10,8 @@ import {
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_CLIENT_SECRET = process.env.INSTAGRAM_CLIENT_SECRET;
 const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
+const APP_URL =
+  process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
 
 function normalizeReturnTo(value: string | null) {
   if (
@@ -22,8 +24,9 @@ function normalizeReturnTo(value: string | null) {
   }
 
   try {
-    const url = new URL(value, "http://pilot.local");
-    if (url.origin !== "http://pilot.local") {
+    // Placeholder origin used only to parse a relative in-app return path safely.
+    const url = new URL(value, "http://localhost.invalid");
+    if (url.origin !== "http://localhost.invalid") {
       return "/settings";
     }
 
@@ -38,7 +41,8 @@ function buildRedirectUrl(
   returnTo: string,
   params: Record<string, string>,
 ) {
-  const url = new URL(returnTo, process.env.NEXT_PUBLIC_APP_URL ?? request.url);
+  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
+  const url = new URL(returnTo, baseUrl);
 
   Object.entries(params).forEach(([key, value]) => {
     url.searchParams.set(key, value);
@@ -47,11 +51,13 @@ function buildRedirectUrl(
   return url.toString();
 }
 
+function getInstagramCallbackUrl(request: Request) {
+  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
+  return new URL("/api/auth/instagram/callback", baseUrl).toString();
+}
+
 export async function GET(request: Request) {
-  const redirectUri = new URL(
-    "/api/auth/instagram/callback",
-    request.url,
-  ).toString();
+  const redirectUri = getInstagramCallbackUrl(request);
   const { searchParams } = new URL(request.url);
   const cookieStore = await cookies();
   const returnTo = normalizeReturnTo(

--- a/apps/app/src/app/api/auth/instagram/callback/route.ts
+++ b/apps/app/src/app/api/auth/instagram/callback/route.ts
@@ -9,12 +9,12 @@ import {
 import {
   getInstagramAppBaseUrl,
   getInstagramCallbackUrl,
+  INSTAGRAM_RETURN_TO_COOKIE,
   normalizeInstagramReturnTo,
 } from "@/lib/instagram-auth";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_CLIENT_SECRET = process.env.INSTAGRAM_CLIENT_SECRET;
-const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
 
 function buildRedirectUrl(
   request: Request,

--- a/apps/app/src/app/api/auth/instagram/route.ts
+++ b/apps/app/src/app/api/auth/instagram/route.ts
@@ -1,46 +1,20 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { buildInstagramAuthUrl } from "@pilot/instagram";
+import {
+  getInstagramCallbackUrl,
+  normalizeInstagramReturnTo,
+} from "@/lib/instagram-auth";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
-const APP_URL =
-  process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
-
-function normalizeReturnTo(value: string | null) {
-  if (
-    !value ||
-    !value.startsWith("/") ||
-    value.startsWith("//") ||
-    value.includes("\\")
-  ) {
-    return "/settings";
-  }
-
-  try {
-    // Placeholder origin used only to parse a relative in-app return path safely.
-    const url = new URL(value, "http://localhost.invalid");
-    if (url.origin !== "http://localhost.invalid") {
-      return "/settings";
-    }
-
-    return `${url.pathname}${url.search}${url.hash}`;
-  } catch {
-    return "/settings";
-  }
-}
-
-function getInstagramCallbackUrl(request: Request) {
-  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
-  return new URL("/api/auth/instagram/callback", baseUrl).toString();
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const cookieStore = await cookies();
   cookieStore.set(
     INSTAGRAM_RETURN_TO_COOKIE,
-    normalizeReturnTo(searchParams.get("returnTo")),
+    normalizeInstagramReturnTo(searchParams.get("returnTo")),
     {
       httpOnly: true,
       maxAge: 60 * 10,

--- a/apps/app/src/app/api/auth/instagram/route.ts
+++ b/apps/app/src/app/api/auth/instagram/route.ts
@@ -1,11 +1,55 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { buildInstagramAuthUrl } from "@pilot/instagram";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
+const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
+
+function normalizeReturnTo(value: string | null) {
+  if (
+    !value ||
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\")
+  ) {
+    return "/settings";
+  }
+
+  try {
+    const url = new URL(value, "http://pilot.local");
+    if (url.origin !== "http://pilot.local") {
+      return "/settings";
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/settings";
+  }
+}
 
 export async function GET(request: Request) {
-  const redirectUri = new URL("/api/auth/instagram/callback", request.url).toString();
-  console.log("Starting Instagram authentication flow with redirect URI:", redirectUri);
+  const { searchParams } = new URL(request.url);
+  const cookieStore = await cookies();
+  cookieStore.set(
+    INSTAGRAM_RETURN_TO_COOKIE,
+    normalizeReturnTo(searchParams.get("returnTo")),
+    {
+      httpOnly: true,
+      maxAge: 60 * 10,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    },
+  );
+
+  const redirectUri = new URL(
+    "/api/auth/instagram/callback",
+    request.url,
+  ).toString();
+  console.log(
+    "Starting Instagram authentication flow with redirect URI:",
+    redirectUri,
+  );
   const authUrl = buildInstagramAuthUrl({
     clientId: INSTAGRAM_CLIENT_ID!,
     redirectUri,

--- a/apps/app/src/app/api/auth/instagram/route.ts
+++ b/apps/app/src/app/api/auth/instagram/route.ts
@@ -3,11 +3,11 @@ import { cookies } from "next/headers";
 import { buildInstagramAuthUrl } from "@pilot/instagram";
 import {
   getInstagramCallbackUrl,
+  INSTAGRAM_RETURN_TO_COOKIE,
   normalizeInstagramReturnTo,
 } from "@/lib/instagram-auth";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
-const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/apps/app/src/app/api/auth/instagram/route.ts
+++ b/apps/app/src/app/api/auth/instagram/route.ts
@@ -4,6 +4,8 @@ import { buildInstagramAuthUrl } from "@pilot/instagram";
 
 const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID;
 const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
+const APP_URL =
+  process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
 
 function normalizeReturnTo(value: string | null) {
   if (
@@ -16,8 +18,9 @@ function normalizeReturnTo(value: string | null) {
   }
 
   try {
-    const url = new URL(value, "http://pilot.local");
-    if (url.origin !== "http://pilot.local") {
+    // Placeholder origin used only to parse a relative in-app return path safely.
+    const url = new URL(value, "http://localhost.invalid");
+    if (url.origin !== "http://localhost.invalid") {
       return "/settings";
     }
 
@@ -25,6 +28,11 @@ function normalizeReturnTo(value: string | null) {
   } catch {
     return "/settings";
   }
+}
+
+function getInstagramCallbackUrl(request: Request) {
+  const baseUrl = APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
+  return new URL("/api/auth/instagram/callback", baseUrl).toString();
 }
 
 export async function GET(request: Request) {
@@ -42,10 +50,7 @@ export async function GET(request: Request) {
     },
   );
 
-  const redirectUri = new URL(
-    "/api/auth/instagram/callback",
-    request.url,
-  ).toString();
+  const redirectUri = getInstagramCallbackUrl(request);
   console.log(
     "Starting Instagram authentication flow with redirect URI:",
     redirectUri,

--- a/apps/app/src/lib/constants/sidekick-onboarding.ts
+++ b/apps/app/src/lib/constants/sidekick-onboarding.ts
@@ -5,25 +5,16 @@ export const sidekickSteps = [
   },
   {
     id: 1,
-    name: "Your Offers",
-  },
-  {
-    id: 2,
     name: "What You Sell",
   },
   {
-    id: 3,
+    id: 2,
     name: "Common Questions",
   },
   {
-    id: 4,
+    id: 3,
     name: "Your Voice",
   },
 ];
 
-export const tone_options = [
-  "Friendly",
-  "Direct",
-  "Like Me",
-  "Custom",
-];
+export const tone_options = ["Friendly", "Direct", "Like Me", "Custom"];

--- a/apps/app/src/lib/instagram-auth.ts
+++ b/apps/app/src/lib/instagram-auth.ts
@@ -1,0 +1,36 @@
+const APP_URL =
+  process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
+
+export function normalizeInstagramReturnTo(value: string | null) {
+  if (
+    !value ||
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\")
+  ) {
+    return "/settings";
+  }
+
+  try {
+    // Placeholder origin used only to parse a relative in-app return path safely.
+    const url = new URL(value, "http://localhost.invalid");
+    if (url.origin !== "http://localhost.invalid") {
+      return "/settings";
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/settings";
+  }
+}
+
+export function getInstagramAppBaseUrl(request: Request) {
+  return APP_URL ? APP_URL.replace(/\/$/, "") : new URL(request.url).origin;
+}
+
+export function getInstagramCallbackUrl(request: Request) {
+  return new URL(
+    "/api/auth/instagram/callback",
+    getInstagramAppBaseUrl(request),
+  ).toString();
+}

--- a/apps/app/src/lib/instagram-auth.ts
+++ b/apps/app/src/lib/instagram-auth.ts
@@ -1,3 +1,5 @@
+export const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
+
 const APP_URL =
   process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a redesigned onboarding flow that prepends two new steps — Instagram connect and an AI-generated DM preview — before the existing profile/goals questionnaire, then redirects users to a sidekick onboarding page. On the sidekick side, the "Offers" and "What You Sell" steps are merged into one combined step, reducing total steps from 5 to 4. A new `instagram-auth.ts` utility centralises shared OAuth helpers, and the Instagram auth routes now support a cookie-based `returnTo` mechanism so the user lands back at the correct page after connecting.

Key changes:
- **New server actions** `prepareInstagramPreview` and `getInstagramOnboardingState` fetch real Instagram DM context and generate an AI reply preview during onboarding.
- **`onboarding/page.tsx`** gains two new steps (Instagram connect at index 0, preview at index 1) and shifts the original three questionnaire steps to indices 2–4.
- **`sidekick-onboarding/page.tsx`** consolidates initialization into a single `Promise.all`, adds an `isMounted` guard, and merges steps 1 and 2.
- **Instagram auth routes** store `returnTo` in an `httpOnly` cookie and redirect back to the originating page on success or failure, rather than always going to `/settings`.
- **`instagram-auth.ts`** extracted as a shared module — fixing the previously flagged `normalizeReturnTo` duplication.

Issues found:
- **`business_type` value format regression** (`onboarding/page.tsx`): The radio group now stores raw option strings (e.g. `"Coach/Consultant"`, `"SaaS"`) instead of the `optionToValue`-normalised forms (`"coach_consultant"`, `"saas"`) used previously. Any user whose `business_type` was saved under the old format will see a blank (unselected) radio group on return, and the "Other" conditional (`watchedBusinessType === "Other"`) won't fire for values stored as `"other"`. All other radio groups in the same file still use `optionToValue`, making this inconsistent.
- **`INSTAGRAM_RETURN_TO_COOKIE` constant duplicated** (`route.ts` and `callback/route.ts`): The string `"pilot_instagram_return_to"` is defined identically in both files rather than exported from the shared `instagram-auth.ts`. A one-sided rename would silently break the OAuth flow.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without addressing the `business_type` value format regression, which will silently break pre-fill for any user with existing partial onboarding data.
- The core Instagram auth flow and new server actions look solid, but the `business_type` radio group now stores raw option strings instead of the `optionToValue`-normalised values used by every other field — and by the existing DB rows. This is a silent data-mismatch regression affecting returning/partial-onboarding users. The duplicated cookie constant is a lower-severity maintenance hazard but not immediately breaking.
- Pay close attention to `apps/app/src/app/(onboarding)/onboarding/page.tsx` — specifically the `business_type` radio group refactor and how it interacts with pre-filled data from `checkOnboardingStatusAndPrefill`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/app/src/actions/onboarding.ts | Adds `prepareInstagramPreview` and `getInstagramOnboardingState` server actions. Logic is well-structured with fallbacks and error boundaries. No new critical issues beyond the previously flagged `message.from` guard. |
| apps/app/src/app/(onboarding)/onboarding/page.tsx | Major revamp adding Instagram connect and preview steps. Contains a data-format regression: `business_type` radio values changed from `optionToValue(option)` to raw option strings, breaking pre-fill for any user with previously saved data. Previously flagged infinite-retry loop on preview failure now guarded by `previewError` in the effect dependency array. |
| apps/app/src/app/(onboarding)/sidekick-onboarding/page.tsx | Merges the "Offers" and "What You Sell" steps into a single combined step. Initialization consolidated into one `Promise.all`, and step indices updated throughout. `isMounted` guard added for async cleanup. No critical bugs identified. |
| apps/app/src/app/api/auth/instagram/callback/route.ts | Reads `returnTo` from a cookie and uses it for all redirects. Previously-flagged `normalizeReturnTo` duplication is now fixed via shared `instagram-auth.ts`. The `INSTAGRAM_RETURN_TO_COOKIE` string constant is still duplicated here and in the initiation route. |
| apps/app/src/app/api/auth/instagram/route.ts | Stores `returnTo` from search params into an `httpOnly` cookie before redirecting to Instagram. Cookie attributes (`sameSite: "lax"`, short `maxAge`) are appropriate for OAuth. `INSTAGRAM_RETURN_TO_COOKIE` constant is duplicated from the callback route. |
| apps/app/src/lib/instagram-auth.ts | New shared utility extracting `normalizeInstagramReturnTo`, `getInstagramAppBaseUrl`, and `getInstagramCallbackUrl`. The open-redirect guard in `normalizeInstagramReturnTo` is thorough and correct. |
| apps/app/src/lib/constants/sidekick-onboarding.ts | Removes "Your Offers" as a separate step (now merged into "What You Sell" step), renumbering remaining steps. Straightforward constants change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OnboardingPage
    participant InstagramRoute as /api/auth/instagram
    participant Instagram
    participant CallbackRoute as /api/auth/instagram/callback
    participant OnboardingActions

    User->>OnboardingPage: Visit /onboarding (Step 0)
    User->>OnboardingPage: Click "Connect Instagram"
    OnboardingPage->>InstagramRoute: GET /api/auth/instagram?returnTo=/onboarding
    InstagramRoute->>InstagramRoute: Store returnTo in httpOnly cookie
    InstagramRoute->>Instagram: Redirect to Instagram OAuth URL
    Instagram->>CallbackRoute: GET /api/auth/instagram/callback?code=...
    CallbackRoute->>CallbackRoute: Read returnTo cookie & delete it
    CallbackRoute->>Instagram: Exchange code for access token
    CallbackRoute->>Instagram: Exchange for long-lived token
    CallbackRoute->>OnboardingActions: saveInstagramConnection()
    CallbackRoute->>OnboardingPage: Redirect to /onboarding?success=instagram_connected

    OnboardingPage->>OnboardingPage: Detect success param → advance to Step 1 (Preview)
    OnboardingPage->>OnboardingActions: prepareInstagramPreview()
    OnboardingActions->>Instagram: fetchConversationsForSync()
    OnboardingActions->>OnboardingActions: selectPreviewConversation()
    OnboardingActions->>OnboardingActions: buildReplyPreview() via Gemini AI
    OnboardingActions->>OnboardingPage: Return preview data

    OnboardingPage->>OnboardingPage: Step 2 – About You
    OnboardingPage->>OnboardingPage: Step 3 – How You Work
    OnboardingPage->>OnboardingPage: Step 4 – Goals
    OnboardingPage->>User: Redirect to /sidekick-onboarding
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/app/src/app/(onboarding)/onboarding/page.tsx`, line 1671 ([link](https://github.com/getpilot/pilot/blob/45583e1e9a4e6c14198287f3ab7f66ca5d4355e9/apps/app/src/app/(onboarding)/onboarding/page.tsx#L1671)) 

   **`business_type` option value format changed, breaking pre-fill for returning users**

   The `business_type` radio group was refactored to use the raw option string (e.g. `"Coach/Consultant"`, `"SaaS"`, `"Other"`) as the form value, instead of the `optionToValue(option)` transformation used everywhere else (which produces `"coach_consultant"`, `"saas"`, `"other"`).

   When `checkOnboardingStatusAndPrefill` runs, it calls:
   ```ts
   step2Form.setValue("business_type", userDataResult.userData.business_type);
   ```
   Any user who saved a `business_type` value under the old format will have the field pre-filled with e.g. `"coach_consultant"` or `"saas"`, but none of the radio `<RadioGroupItem value={option}>` elements will have those values — they now expect `"Coach/Consultant"` or `"SaaS"`. The result is a blank (unselected) radio group, and the "Tell us about your business type" conditional (`watchedBusinessType === "Other"`) will also never fire for users who previously selected "Other" (stored as `"other"`).

   This affects any user who partially completed onboarding and returns to the page, or any database row where `business_type` was previously saved.

   Either revert to using `optionToValue(option)` as the radio value (consistent with `gender`, `use_case`, `active_platforms`, and `current_tracking`), or migrate existing DB values to the new casing.

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/app/src/app/api/auth/instagram/route.ts
Line: 14

Comment:
**`INSTAGRAM_RETURN_TO_COOKIE` duplicated across both route files**

`INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to"` is defined identically here and in `apps/app/src/app/api/auth/instagram/callback/route.ts` (line 17). If the cookie name is ever changed in one file but not the other, the OAuth flow breaks silently — the callback route reads a cookie that was stored under a different name, `returnTo` resolves to `"/settings"`, and the user ends up in the wrong place after connecting Instagram.

Since `instagram-auth.ts` already exists as the shared utility module for this flow, the constant belongs there:

```ts
// apps/app/src/lib/instagram-auth.ts
export const INSTAGRAM_RETURN_TO_COOKIE = "pilot_instagram_return_to";
```

Then import it in both route files instead of redefining it. The same issue is present in the callback route at `apps/app/src/app/api/auth/instagram/callback/route.ts:17`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/app/src/app/(onboarding)/onboarding/page.tsx
Line: 1671

Comment:
**`business_type` option value format changed, breaking pre-fill for returning users**

The `business_type` radio group was refactored to use the raw option string (e.g. `"Coach/Consultant"`, `"SaaS"`, `"Other"`) as the form value, instead of the `optionToValue(option)` transformation used everywhere else (which produces `"coach_consultant"`, `"saas"`, `"other"`).

When `checkOnboardingStatusAndPrefill` runs, it calls:
```ts
step2Form.setValue("business_type", userDataResult.userData.business_type);
```
Any user who saved a `business_type` value under the old format will have the field pre-filled with e.g. `"coach_consultant"` or `"saas"`, but none of the radio `<RadioGroupItem value={option}>` elements will have those values — they now expect `"Coach/Consultant"` or `"SaaS"`. The result is a blank (unselected) radio group, and the "Tell us about your business type" conditional (`watchedBusinessType === "Other"`) will also never fire for users who previously selected "Other" (stored as `"other"`).

This affects any user who partially completed onboarding and returns to the page, or any database row where `business_type` was previously saved.

Either revert to using `optionToValue(option)` as the radio value (consistent with `gender`, `use_case`, `active_platforms`, and `current_tracking`), or migrate existing DB values to the new casing.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 45583e1</sub>

<!-- /greptile_comment -->