### PR TITLE
improve marketing SEO and AI discoverability

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -24,10 +24,25 @@ const fontHeading = Prata({
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.origin),
-  title: siteConfig.title,
+  title: {
+    default: siteConfig.title,
+    template: "%s | Pilot Dashboard",
+  },
   description: siteConfig.description,
   keywords: siteConfig.keywords,
   creator: siteConfig.creator.name,
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+      "max-image-preview": "none",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
   icons: {
     icon: "/logo.png",
     shortcut: "/logo.png",

--- a/apps/app/src/app/robots.ts
+++ b/apps/app/src/app/robots.ts
@@ -2,31 +2,9 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [
-      {
-        userAgent: "*",
-        disallow: "/",
-      },
-      {
-        userAgent: "GPTBot",
-        disallow: "/",
-      },
-      {
-        userAgent: "ChatGPT-User",
-        disallow: "/",
-      },
-      {
-        userAgent: "Google-Extended",
-        disallow: "/",
-      },
-      {
-        userAgent: "PerplexityBot",
-        disallow: "/",
-      },
-      {
-        userAgent: "ClaudeBot",
-        disallow: "/",
-      },
-    ],
+    rules: {
+      userAgent: "*",
+      disallow: "/",
+    },
   };
 }

--- a/apps/app/src/app/robots.ts
+++ b/apps/app/src/app/robots.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        disallow: "/",
+      },
+      {
+        userAgent: "GPTBot",
+        disallow: "/",
+      },
+      {
+        userAgent: "ChatGPT-User",
+        disallow: "/",
+      },
+      {
+        userAgent: "Google-Extended",
+        disallow: "/",
+      },
+      {
+        userAgent: "PerplexityBot",
+        disallow: "/",
+      },
+      {
+        userAgent: "ClaudeBot",
+        disallow: "/",
+      },
+    ],
+  };
+}

--- a/apps/app/src/config/site.config.ts
+++ b/apps/app/src/config/site.config.ts
@@ -2,20 +2,16 @@ import { SiteConfig } from "@pilot/types";
 
 export const siteConfig: SiteConfig = {
   name: "Pilot",
-  title: "Pilot — Turn Instagram DMs Into Qualified Leads",
+  title: "Pilot Dashboard",
   description:
-    "AI-powered Instagram sales system for lead management and revenue operations — built for creators, entrepreneurs, and social teams who want conversions, not brittle flow-builder bots.",
+    "Pilot dashboard for account access, onboarding, billing, contacts, automations, and Sidekick operations.",
   origin: "https://dashboard.trypilot.app/",
   keywords: [
-    "social media",
-    "infoproducts",
-    "high ticket",
-    "contacts",
-    "pipeline",
-    "future",
-    "agentic",
-    "automatic",
-    "sales",
+    "pilot dashboard",
+    "instagram automation dashboard",
+    "instagram crm dashboard",
+    "pilot app",
+    "dm automation workspace",
   ],
   og: "https://dashboard.trypilot.app/og.png",
   creator: {

--- a/apps/web/src/app/(main)/comment-to-dm-automation/page.tsx
+++ b/apps/web/src/app/(main)/comment-to-dm-automation/page.tsx
@@ -1,0 +1,217 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@pilot/ui/components/button";
+import { RelatedReading } from "@/components/marketing/related-reading";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
+  researchSources,
+} from "@/lib/seo";
+
+const pageTitle = "Comment-to-DM Automation";
+const pageDescription =
+  "Learn how comment-to-DM automation works, where it creates pipeline, and how to keep it safe and conversion-focused on Instagram.";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  path: "/comment-to-dm-automation",
+  keywords: [
+    "comment to dm automation",
+    "instagram comment to dm automation",
+    "instagram comment automation",
+  ],
+});
+
+const principles = [
+  {
+    title: "Move interest into a private conversation fast",
+    body: "The point of comment-to-DM automation is not just to acknowledge a comment. It is to shift a warm public signal into a private thread where qualification and follow-up can continue without friction.",
+  },
+  {
+    title: "Keep the first DM contextual",
+    body: "The opening message should reflect the post, the offer, or the intent behind the trigger. Generic canned replies feel spammy and reduce trust even when the automation itself technically works.",
+  },
+  {
+    title: "Hand off when the thread stops being obvious",
+    body: "Once the conversation hits pricing nuance, delivery questions, refund concerns, or emotional context, operators need a clean handoff path rather than more automation pressure.",
+  },
+];
+
+const CommentToDMAutomationPage = () => {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              {
+                name: "Comment-to-DM Automation",
+                path: "/comment-to-dm-automation",
+              },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/comment-to-dm-automation",
+            }),
+          ),
+        }}
+      />
+
+      <div className="max-w-4xl">
+        <p className="text-sm font-medium text-primary">Guide</p>
+        <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Comment-to-DM automation that moves conversations into pipeline
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {MARKETING_LAST_UPDATED_LABEL}
+        </p>
+        <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
+          Comment-to-DM automation works best when it turns visible demand into
+          a clear next step. The goal is not to blast every commenter. The goal
+          is to open a private conversation quickly, preserve context from the
+          original post, and qualify the lead without making the brand feel
+          robotic.
+        </p>
+      </div>
+
+      <section className="mt-12 grid gap-4 md:grid-cols-3">
+        <article className="rounded-2xl border bg-card p-6">
+          <p className="font-heading text-4xl text-foreground">73%</p>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            of social users say they will buy from a competitor if a brand does
+            not respond on social.
+          </p>
+          <Link
+            href={researchSources.competitorRisk.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex text-sm text-primary underline underline-offset-4"
+          >
+            Source: {researchSources.competitorRisk.name}
+          </Link>
+        </article>
+        <article className="rounded-2xl border bg-card p-6">
+          <p className="font-heading text-4xl text-foreground">73%</p>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            expect brands to respond on social within 24 hours or sooner.
+          </p>
+          <Link
+            href={researchSources.socialResponseWindow.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex text-sm text-primary underline underline-offset-4"
+          >
+            Source: {researchSources.socialResponseWindow.name}
+          </Link>
+        </article>
+        <article className="rounded-2xl border bg-card p-6">
+          <p className="font-heading text-4xl text-foreground">35%</p>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            of U.S. consumers used Instagram for customer service in Sprout&apos;s
+            2022 Index, cited again in its 2025 customer-service analysis.
+          </p>
+          <Link
+            href="https://sproutsocial.com/insights/social-media-customer-service-statistics/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex text-sm text-primary underline underline-offset-4"
+          >
+            Source: Sprout Social customer service analysis
+          </Link>
+        </article>
+      </section>
+
+      <section className="mt-16 grid gap-6 md:grid-cols-3">
+        {principles.map((principle) => (
+          <article key={principle.title} className="rounded-2xl border bg-card p-6">
+            <h2 className="font-heading text-2xl text-foreground">
+              {principle.title}
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {principle.body}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <h2 className="font-heading text-3xl text-foreground">
+          What a stronger comment-to-DM workflow looks like
+        </h2>
+        <div className="mt-6 grid gap-6 md:grid-cols-2">
+          <div>
+            <h3 className="text-lg font-medium text-foreground">
+              Workflow essentials
+            </h3>
+            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+              <li>Trigger the DM from a relevant post or offer</li>
+              <li>Reference the original context in the first message</li>
+              <li>Capture the contact in a CRM-style record immediately</li>
+              <li>Route edge cases to a human before the thread degrades</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">
+              Common failure modes
+            </h3>
+            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+              <li>Sending the same message regardless of the post context</li>
+              <li>Treating every commenter like a sales-ready lead</li>
+              <li>No visibility into who replied, converted, or stalled</li>
+              <li>No handoff rule for pricing, policy, or emotional questions</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <RelatedReading
+        links={[
+          {
+            href: "/instagram-dm-automation",
+            title: "Instagram DM automation guide",
+            description:
+              "The broader category guide for teams evaluating automation, qualification, and human handoff.",
+          },
+          {
+            href: "/pilot-vs-manychat",
+            title: "Pilot vs ManyChat",
+            description:
+              "A practical comparison for teams deciding between a flow builder and a sales-system approach.",
+          },
+          {
+            href: "/pricing",
+            title: "Pilot pricing",
+            description:
+              "See how Pilot packages contacts, automations, and AI-assisted workflow volume.",
+          },
+        ]}
+      />
+
+      <div className="mt-12 flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href="/waitlist">Join waitlist</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/instagram-dm-automation">
+            Read the Instagram DM automation guide
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default CommentToDMAutomationPage;

--- a/apps/web/src/app/(main)/creator-dm-proof/page.tsx
+++ b/apps/web/src/app/(main)/creator-dm-proof/page.tsx
@@ -1,0 +1,197 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@pilot/ui/components/button";
+import { RelatedReading } from "@/components/marketing/related-reading";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
+} from "@/lib/seo";
+
+const pageTitle = "Creator DM Proof";
+const pageDescription =
+  "A compact case-study style proof page showing how Pilot helps creator-led teams stop losing warm Instagram leads in DMs.";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  path: "/creator-dm-proof",
+  keywords: [
+    "instagram dm conversion case study",
+    "creator dm automation proof",
+    "instagram lead conversion proof",
+  ],
+});
+
+const workflowSteps = [
+  {
+    title: "The setup",
+    body: "Warm leads were arriving through comments, story replies, and inbound DMs, but the conversation context kept breaking. Operators had to remember the offer, the previous reply, and whether someone was still worth following up with.",
+  },
+  {
+    title: "Where rule-based automation broke down",
+    body: "The old approach could route simple intent, but it could not gracefully handle mixed signals, buying questions, or nuanced follow-ups without turning into a brittle tree of conditions. The team spent time managing logic instead of moving conversations forward.",
+  },
+  {
+    title: "What Pilot changed",
+    body: "Pilot treated the inbox like pipeline. The AI layer could work from business context, offers, FAQs, and conversation state while keeping human handoff available when the thread became sensitive or commercially important.",
+  },
+  {
+    title: "Why this performs better",
+    body: "The system stopped acting like a static autoresponder. Instead of only firing rigid rules, it helped teams reply in context, continue the sales conversation, and surface follow-up tasks before warm intent cooled off.",
+  },
+];
+
+const proofSignals = [
+  "AI-native replies grounded in business context, not just a trigger map",
+  "Lead qualification and follow-up live in the same workflow as the conversation",
+  "Operators get a cleaner handoff path when pricing or nuance requires a human",
+];
+
+const caseStudyNotes = [
+  {
+    title: "Page type",
+    body: "This is a proof-style workflow page, not a named customer case study with published revenue numbers.",
+  },
+  {
+    title: "What it demonstrates",
+    body: "The point is to show the operational difference between rule-first DM automation and AI-native, context-aware DM conversion workflows.",
+  },
+  {
+    title: "Why it matters",
+    body: "In creator-led sales motions, the biggest leak is often not traffic. It is warm intent going unmanaged inside DMs after content already did the hard work.",
+  },
+];
+
+const CreatorDMProofPage = () => {
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Creator DM Proof", path: "/creator-dm-proof" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/creator-dm-proof",
+            }),
+          ),
+        }}
+      />
+
+      <div className="max-w-4xl">
+        <p className="text-sm font-medium text-primary">Proof</p>
+        <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          A compact proof page for how Pilot converts warmer Instagram DMs
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {MARKETING_LAST_UPDATED_LABEL}
+        </p>
+        <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
+          This is a compact case-study style page built around the workflow
+          problems we repeatedly hear from creator-led teams in early access:
+          too many warm leads stuck in DMs, too much manual recall, and too
+          many conversations that never reach a clear next step.
+        </p>
+      </div>
+
+      <section className="mt-12 rounded-[2rem] border border-border/70 bg-card/60 p-6 shadow-sm sm:p-8">
+        <blockquote className="font-heading max-w-3xl text-2xl leading-tight tracking-tight text-foreground sm:text-3xl">
+          &quot;Pilot gave us the follow-up discipline we were missing. Warm leads
+          stopped slipping through inbox cracks.&quot;
+        </blockquote>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Early access customer, creator-led business operator
+        </p>
+      </section>
+
+      <section className="mt-10 grid gap-4 md:grid-cols-3">
+        {caseStudyNotes.map((note) => (
+          <article key={note.title} className="rounded-2xl border bg-card p-5">
+            <h2 className="text-lg font-medium text-foreground">{note.title}</h2>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {note.body}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-16 grid gap-6 md:grid-cols-2">
+        {workflowSteps.map((step) => (
+          <article key={step.title} className="rounded-2xl border bg-card p-6">
+            <h2 className="font-heading text-2xl text-foreground">
+              {step.title}
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {step.body}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <h2 className="font-heading text-3xl text-foreground">
+          The practical difference
+        </h2>
+        <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          ManyChat is often strongest when the workflow can stay inside a rigid
+          rule tree. Pilot is strongest when the business needs a more adaptive,
+          AI-native system that understands the offer, the buyer context, and
+          the current state of the thread well enough to keep moving the lead
+          toward conversion.
+        </p>
+        <ul className="mt-6 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+          {proofSignals.map((signal) => (
+            <li key={signal}>{signal}</li>
+          ))}
+        </ul>
+      </section>
+
+      <RelatedReading
+        links={[
+          {
+            href: "/pilot-vs-manychat",
+            title: "Pilot vs ManyChat",
+            description:
+              "See the alternatives page focused on pricing, AI-native conversion, and open-source control.",
+          },
+          {
+            href: "/comment-to-dm-automation",
+            title: "Comment-to-DM automation",
+            description:
+              "Understand how post engagement turns into private sales conversations.",
+          },
+          {
+            href: "/pricing",
+            title: "Pilot pricing",
+            description:
+              "Review the pricing model for teams scaling contacts, workflows, and AI-assisted actions.",
+          },
+        ]}
+      />
+
+      <div className="mt-12 flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href="/waitlist">Join waitlist</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/pilot-vs-manychat">Read the full comparison</Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default CreatorDMProofPage;

--- a/apps/web/src/app/(main)/instagram-dm-automation/page.tsx
+++ b/apps/web/src/app/(main)/instagram-dm-automation/page.tsx
@@ -1,0 +1,165 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@pilot/ui/components/button";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  buildPageMetadata,
+  researchSources,
+} from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Instagram DM Automation Guide",
+  description:
+    "Learn what Instagram DM automation should do, what teams should look for in a tool, and how Pilot handles follow-up, routing, and lead qualification.",
+  path: "/instagram-dm-automation",
+  keywords: [
+    "instagram dm automation",
+    "instagram comment to dm automation",
+    "instagram lead management",
+  ],
+});
+
+const proofCards = [
+  {
+    stat: "73%",
+    title: "expect a response within 24 hours or sooner",
+    source: researchSources.socialResponseWindow,
+  },
+  {
+    stat: "73%",
+    title: "say they will buy from a competitor if a brand does not respond on social",
+    source: researchSources.competitorRisk,
+  },
+  {
+    stat: "35%",
+    title: "of U.S. consumers used Instagram for customer service in Sprout's 2022 Index, cited in its 2025 customer service analysis",
+    source: {
+      name: "Sprout Social customer service analysis",
+      url: "https://sproutsocial.com/insights/social-media-customer-service-statistics/",
+      stat: "Our 2022 Sprout Social Index found that 35% of U.S. consumers use Instagram for customer service.",
+    },
+  },
+];
+
+const sections = [
+  {
+    title: "What Instagram DM automation should actually solve",
+    body: "Good Instagram automation does more than send a canned reply. It should capture buying signals from DMs and comments, preserve context across the thread, route risky cases to a human, and keep lead data attached to the conversation.",
+  },
+  {
+    title: "Where basic flow-builders fall short",
+    body: "Most DM tools are optimized for trigger maps, not revenue operations. Teams outgrow them when they need CRM context, nuanced replies, lead scoring, ownership, or a safe way to pause automation when a thread gets sensitive.",
+  },
+  {
+    title: "How Pilot approaches the problem",
+    body: "Pilot treats Instagram messaging like a live pipeline. It combines AI-assisted classification, reply generation, contact records, workflow controls, and human-response-needed routing so follow-up stays fast without becoming reckless.",
+  },
+];
+
+const InstagramDMAutomationPage = () => {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <div className="max-w-4xl">
+        <p className="text-sm font-medium text-primary">Guide</p>
+        <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Instagram DM automation for teams that care about conversion quality
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {MARKETING_LAST_UPDATED_LABEL}
+        </p>
+        <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
+          Instagram DM automation works best when it behaves like a sales system,
+          not a brittle autoresponder. The goal is to respond quickly, keep lead
+          context intact, and know exactly when a human should step in.
+        </p>
+      </div>
+
+      <section className="mt-12 grid gap-4 md:grid-cols-3">
+        {proofCards.map((card) => (
+          <article key={card.title} className="rounded-2xl border bg-card p-6">
+            <p className="font-heading text-4xl text-foreground">{card.stat}</p>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {card.title}
+            </p>
+            <Link
+              href={card.source.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex text-sm text-primary underline underline-offset-4"
+            >
+              Source: {card.source.name}
+            </Link>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-16 grid gap-6 md:grid-cols-3">
+        {sections.map((section) => (
+          <article key={section.title} className="rounded-2xl border bg-card p-6">
+            <h2 className="font-heading text-2xl text-foreground">
+              {section.title}
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {section.body}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <h2 className="font-heading text-3xl text-foreground">
+          What to look for in an Instagram automation stack
+        </h2>
+        <div className="mt-6 grid gap-6 md:grid-cols-2">
+          <div>
+            <h3 className="text-lg font-medium text-foreground">
+              Operations requirements
+            </h3>
+            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+              <li>Shared inbox visibility across DMs, comments, and follow-up</li>
+              <li>Lead records with stage, owner, notes, and sentiment</li>
+              <li>Safe escalation rules for risky or nuanced conversations</li>
+              <li>Pricing that stays predictable as conversation volume grows</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">
+              Buyer questions to ask
+            </h3>
+            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+              <li>Can the tool move from comment to DM without losing context?</li>
+              <li>Does it support human handoff before a thread goes sideways?</li>
+              <li>Can operators audit what the automation is doing?</li>
+              <li>Is pricing transparent enough for both humans and AI buyers?</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <h2 className="font-heading text-3xl text-foreground">
+          How to roll out DM automation without hurting trust
+        </h2>
+        <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          Start with the highest-intent entry points first: warm inbound DMs,
+          repeat questions, and comment-trigger follow-up that leads to a real
+          next step. Keep humans in the loop for refund requests, policy-heavy
+          conversations, pricing exceptions, and emotionally charged threads.
+          The best automation stack is the one that speeds up simple conversations
+          while making handoff obvious when nuance matters.
+        </p>
+      </section>
+
+      <div className="mt-12 flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href="/waitlist">Join waitlist</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/pilot-vs-manychat">Compare Pilot vs ManyChat</Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default InstagramDMAutomationPage;

--- a/apps/web/src/app/(main)/instagram-dm-automation/page.tsx
+++ b/apps/web/src/app/(main)/instagram-dm-automation/page.tsx
@@ -1,16 +1,22 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@pilot/ui/components/button";
+import { RelatedReading } from "@/components/marketing/related-reading";
 import {
   MARKETING_LAST_UPDATED_LABEL,
   buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
   researchSources,
 } from "@/lib/seo";
 
+const pageTitle = "Instagram DM Automation Guide";
+const pageDescription =
+  "Learn what Instagram DM automation should do, what teams should look for in a tool, and how Pilot handles follow-up, routing, and lead qualification.";
+
 export const metadata: Metadata = buildPageMetadata({
-  title: "Instagram DM Automation Guide",
-  description:
-    "Learn what Instagram DM automation should do, what teams should look for in a tool, and how Pilot handles follow-up, routing, and lead qualification.",
+  title: pageTitle,
+  description: pageDescription,
   path: "/instagram-dm-automation",
   keywords: [
     "instagram dm automation",
@@ -59,6 +65,29 @@ const sections = [
 const InstagramDMAutomationPage = () => {
   return (
     <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Instagram DM Automation", path: "/instagram-dm-automation" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/instagram-dm-automation",
+            }),
+          ),
+        }}
+      />
       <div className="max-w-4xl">
         <p className="text-sm font-medium text-primary">Guide</p>
         <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
@@ -149,6 +178,29 @@ const InstagramDMAutomationPage = () => {
           while making handoff obvious when nuance matters.
         </p>
       </section>
+
+      <RelatedReading
+        links={[
+          {
+            href: "/comment-to-dm-automation",
+            title: "Comment-to-DM automation",
+            description:
+              "A more specific guide on turning public post engagement into private pipeline.",
+          },
+          {
+            href: "/pilot-vs-manychat",
+            title: "Pilot vs ManyChat",
+            description:
+              "Compare the category tradeoffs between a flow-builder and a sales-system approach.",
+          },
+          {
+            href: "/pricing",
+            title: "Pilot pricing",
+            description:
+              "Review the plans for teams scaling contacts, automations, and AI-assisted workflow volume.",
+          },
+        ]}
+      />
 
       <div className="mt-12 flex flex-wrap gap-3">
         <Button asChild>

--- a/apps/web/src/app/(main)/manifesto/page.tsx
+++ b/apps/web/src/app/(main)/manifesto/page.tsx
@@ -1,3 +1,14 @@
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "The Pilot Manifesto",
+  description:
+    "Read the product philosophy behind Pilot: Instagram automation with CRM depth, account-safety guardrails, and open-source control.",
+  path: "/manifesto",
+  keywords: ["pilot manifesto", "instagram automation philosophy"],
+});
+
 const ManifestoPage = () => {
   return (
     <main className="mx-auto w-full max-w-4xl px-4 pt-24 md:mt-16 pb-16 sm:px-6 lg:px-8">

--- a/apps/web/src/app/(main)/manifesto/page.tsx
+++ b/apps/web/src/app/(main)/manifesto/page.tsx
@@ -1,17 +1,47 @@
 import type { Metadata } from "next";
-import { buildPageMetadata } from "@/lib/seo";
+import {
+  buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
+} from "@/lib/seo";
+
+const pageTitle = "The Pilot Manifesto";
+const pageDescription =
+  "Read the product philosophy behind Pilot: Instagram automation with CRM depth, account-safety guardrails, and open-source control.";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "The Pilot Manifesto",
-  description:
-    "Read the product philosophy behind Pilot: Instagram automation with CRM depth, account-safety guardrails, and open-source control.",
+  title: pageTitle,
+  description: pageDescription,
   path: "/manifesto",
   keywords: ["pilot manifesto", "instagram automation philosophy"],
 });
 
 const ManifestoPage = () => {
   return (
-    <main className="mx-auto w-full max-w-4xl px-4 pt-24 md:mt-16 pb-16 sm:px-6 lg:px-8">
+    <main className="mx-auto w-full max-w-4xl px-4 pt-24 pb-16 sm:px-6 md:mt-16 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Manifesto", path: "/manifesto" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/manifesto",
+            }),
+          ),
+        }}
+      />
       <p className="text-sm font-medium text-primary">Manifesto</p>
       <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
         The Pilot Manifesto
@@ -48,8 +78,9 @@ const ManifestoPage = () => {
           visibility, lead scoring, attribution, and automation diagnostics.
         </p>
         <p>If this matches how you work, join us and build with us.</p>
-        <p>— The Pilot team</p>
+        <p>The Pilot team</p>
       </div>
+
     </main>
   );
 };

--- a/apps/web/src/app/(main)/open-source/page.tsx
+++ b/apps/web/src/app/(main)/open-source/page.tsx
@@ -1,6 +1,19 @@
-import Link from "next/link"
-import { ArrowUpRight } from "lucide-react"
-import { Button } from "@pilot/ui/components/button"
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { Button } from "@pilot/ui/components/button";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Why Pilot Is Open Source",
+  description:
+    "See why Pilot is open source by design, how self-hosting fits the product, and why transparency matters for Instagram sales infrastructure.",
+  path: "/open-source",
+  keywords: [
+    "open source instagram automation",
+    "self-hosted instagram crm",
+  ],
+});
 
 const OpenSourcePage = () => {
   return (
@@ -90,6 +103,6 @@ const OpenSourcePage = () => {
       </div>
     </main>
   )
-}
+};
 
-export default OpenSourcePage
+export default OpenSourcePage;

--- a/apps/web/src/app/(main)/open-source/page.tsx
+++ b/apps/web/src/app/(main)/open-source/page.tsx
@@ -2,12 +2,19 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { Button } from "@pilot/ui/components/button";
-import { buildPageMetadata } from "@/lib/seo";
+import {
+  buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
+} from "@/lib/seo";
+
+const pageTitle = "Why Pilot Is Open Source";
+const pageDescription =
+  "See why Pilot is open source by design, how self-hosting fits the product, and why transparency matters for Instagram sales infrastructure.";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "Why Pilot Is Open Source",
-  description:
-    "See why Pilot is open source by design, how self-hosting fits the product, and why transparency matters for Instagram sales infrastructure.",
+  title: pageTitle,
+  description: pageDescription,
   path: "/open-source",
   keywords: [
     "open source instagram automation",
@@ -18,6 +25,29 @@ export const metadata: Metadata = buildPageMetadata({
 const OpenSourcePage = () => {
   return (
     <main className="mx-auto w-full max-w-4xl px-4 pt-24 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Open Source", path: "/open-source" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/open-source",
+            }),
+          ),
+        }}
+      />
       <p className="text-sm font-medium text-primary">Open Source</p>
       <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
         Why Pilot is open source by design

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import CallToAction from "@/components/landing/call-to-action";
 import FAQSection from "@/components/landing/faq";
 import Features from "@/components/landing/features";
@@ -7,12 +8,55 @@ import Pricing from "@/components/landing/pricing";
 import SolarAnalytics from "@/components/landing/product-overview";
 import Testimonial from "@/components/landing/testimonial";
 import CompareTable from "@/components/landing/compare";
+import {
+  buildPageMetadata,
+  getFaqSchema,
+  getOrganizationSchema,
+  getSoftwareApplicationSchema,
+  getWebsiteSchema,
+} from "@/lib/seo";
 import { BlurFade } from "@pilot/ui/components/blur-fade";
 import Supporters from "@pilot/ui/components/supporters";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Turn Instagram DMs Into Qualified Leads",
+  description:
+    "Pilot helps creators, founders, and social teams turn Instagram DMs into qualified pipeline with AI replies, CRM context, and human handoff guardrails.",
+  path: "/",
+  keywords: [
+    "instagram dm automation software",
+    "instagram lead management software",
+    "instagram sales crm",
+  ],
+});
 
 const HomePage = () => {
   return (
     <main className="relative mx-auto flex flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getOrganizationSchema()),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getWebsiteSchema()),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getSoftwareApplicationSchema()),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getFaqSchema()),
+        }}
+      />
       <BlurFade
         delay={0.06}
         inView

--- a/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
+++ b/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import CompareTable from "@/components/landing/compare";
+import { Button } from "@pilot/ui/components/button";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  buildPageMetadata,
+} from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Pilot vs ManyChat",
+  description:
+    "Compare Pilot vs ManyChat for Instagram DM automation, CRM depth, AI replies, pricing model, and open-source control.",
+  path: "/pilot-vs-manychat",
+  keywords: [
+    "pilot vs manychat",
+    "manychat alternative",
+    "instagram dm automation comparison",
+  ],
+});
+
+const comparisonBullets = [
+  "Pilot is built for teams that want one system for inbox automation, lead qualification, and CRM context.",
+  "ManyChat is stronger today for visual flow mapping and multi-channel breadth, but Pilot is stronger on AI-native replies, pipeline context, and self-host control.",
+  "If your team cares about account safety, human handoff, and predictable economics as volume grows, Pilot is the sharper fit.",
+];
+
+const PilotVsManyChatPage = () => {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <div className="max-w-4xl">
+        <p className="text-sm font-medium text-primary">Comparison</p>
+        <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Pilot vs ManyChat for Instagram DM automation
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {MARKETING_LAST_UPDATED_LABEL}
+        </p>
+        <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
+          This page is for teams evaluating whether they need a traditional
+          flow-builder or a more modern Instagram sales system. Pilot focuses on
+          qualifying demand, keeping CRM context attached to every thread, and
+          escalating sensitive conversations before automation becomes risky.
+        </p>
+      </div>
+
+      <div className="mt-10 grid gap-4 md:grid-cols-3">
+        {comparisonBullets.map((bullet) => (
+          <div key={bullet} className="rounded-2xl border bg-card p-6">
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {bullet}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-14">
+        <CompareTable
+          showPageLink={false}
+          title="Feature-by-feature breakdown"
+          description="A practical view of where Pilot is stronger today, where ManyChat still has the edge, and what those tradeoffs mean for an Instagram-first team."
+        />
+      </div>
+
+      <section className="mt-16 grid gap-6 md:grid-cols-2">
+        <article className="rounded-2xl border bg-card p-6">
+          <h2 className="font-heading text-2xl text-foreground">
+            Choose Pilot if you want
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+            <li>AI-assisted replies with CRM memory across threads</li>
+            <li>Human response needed guardrails for risky conversations</li>
+            <li>Self-hostable infrastructure and transparent product direction</li>
+            <li>Pricing that does not punish audience growth</li>
+          </ul>
+        </article>
+        <article className="rounded-2xl border bg-card p-6">
+          <h2 className="font-heading text-2xl text-foreground">
+            Choose ManyChat if you need
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+            <li>A mature visual flow builder today</li>
+            <li>Broader channel coverage across Facebook, WhatsApp, and SMS</li>
+            <li>A larger existing integration ecosystem out of the box</li>
+          </ul>
+        </article>
+      </section>
+
+      <div className="mt-12 flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href="/pricing">View Pilot pricing</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/instagram-dm-automation">
+            Read the Instagram DM automation guide
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default PilotVsManyChatPage;

--- a/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
+++ b/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
@@ -26,9 +26,24 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 const comparisonBullets = [
-  "Pilot is built for teams that want one system for inbox automation, lead qualification, and CRM context.",
-  "ManyChat is stronger today for visual flow mapping and multi-channel breadth, but Pilot is stronger on AI-native replies, pipeline context, and self-host control.",
-  "If your team cares about account safety, human handoff, and predictable economics as volume grows, Pilot is the sharper fit.",
+  "Pilot is built for teams that want one system for inbox automation, lead qualification, and CRM context instead of a separate chatbot layer.",
+  "ManyChat is still stronger for visual flow mapping and broader packaged channel support, but Pilot is stronger when the job is conversion quality inside Instagram DMs.",
+  "If your team cares about predictable pricing, business-aware AI replies, and open-source control, Pilot is the sharper alternative.",
+];
+
+const proofMoments = [
+  {
+    title: "Warm intent arrives in bursts",
+    body: "A post, reel, or story can create dozens of simultaneous DM threads. That is exactly when rigid flow logic starts to show its limits and when revenue leaks through follow-up gaps.",
+  },
+  {
+    title: "Rule trees protect logic, not context",
+    body: "ManyChat can route users through clear branches, but the system still depends on you predicting every path in advance. Pilot is designed to understand the business context around the conversation, not just the trigger that started it.",
+  },
+  {
+    title: "The closer the thread gets to purchase, the more context matters",
+    body: "Price objections, intent shifts, and handoff moments are rarely clean if/else branches. Pilot is better aligned with those real sales conversations because the AI layer is meant to operate on context, not just routing rules.",
+  },
 ];
 
 const PilotVsManyChatPage = () => {
@@ -67,9 +82,10 @@ const PilotVsManyChatPage = () => {
         </p>
         <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
           This page is for teams evaluating whether they need a traditional
-          flow-builder or a more modern Instagram sales system. Pilot focuses on
-          qualifying demand, keeping CRM context attached to every thread, and
-          escalating sensitive conversations before automation becomes risky.
+          flow-builder or a more modern Instagram sales system. Pilot focuses
+          on qualifying demand, keeping CRM context attached to every thread,
+          and escalating sensitive conversations before automation becomes
+          risky.
         </p>
       </div>
 
@@ -83,6 +99,56 @@ const PilotVsManyChatPage = () => {
         ))}
       </div>
 
+      <section className="mt-16 rounded-[2rem] border border-border/70 bg-card/60 p-6 shadow-sm sm:p-8">
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary/80">
+            Focus areas
+          </p>
+          <h2 className="font-heading mt-3 text-3xl text-foreground sm:text-4xl">
+            Why teams usually pick Pilot over ManyChat
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+            The three biggest reasons are usually pricing clarity, AI-native
+            conversion workflows, and open-source control. This is where the
+            product experience feels fundamentally different, not just
+            cosmetically different.
+          </p>
+        </div>
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          <article className="rounded-2xl border bg-background/70 p-5">
+            <h3 className="font-heading text-2xl text-foreground">
+              Pricing that is easier to forecast
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Pilot shows public plan bands and what each one includes. That
+              makes it easier for teams to estimate spend before a campaign or a
+              viral post drives new conversations into the system.
+            </p>
+          </article>
+          <article className="rounded-2xl border bg-background/70 p-5">
+            <h3 className="font-heading text-2xl text-foreground">
+              AI-native instead of rule-map-first
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              ManyChat is strongest when you want a rigid trigger tree. Pilot is
+              built around business-aware AI that can work from your offers,
+              FAQs, tone, lead context, and handoff rules to move the thread
+              toward conversion instead of only routing through predefined maps.
+            </p>
+          </article>
+          <article className="rounded-2xl border bg-background/70 p-5">
+            <h3 className="font-heading text-2xl text-foreground">
+              Open source and self-host control
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Pilot gives teams an inspectable, forkable path instead of forcing
+              them into a closed automation layer. That matters when the system
+              touches customer conversations and revenue operations.
+            </p>
+          </article>
+        </div>
+      </section>
+
       <div className="mt-14">
         <CompareTable
           showPageLink={false}
@@ -90,6 +156,54 @@ const PilotVsManyChatPage = () => {
           description="A practical view of where Pilot is stronger today, where ManyChat still has the edge, and what those tradeoffs mean for an Instagram-first team."
         />
       </div>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary/80">
+            Case-study lens
+          </p>
+          <h2 className="font-heading mt-3 text-3xl text-foreground">
+            Why this comparison matters in a real buying workflow
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Most teams do not switch tools because they suddenly love software
+            comparisons. They switch because inbound demand is already there and
+            the current system is too rigid to keep up with how people actually
+            buy in DMs.
+          </p>
+        </div>
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          {proofMoments.map((moment) => (
+            <article key={moment.title} className="rounded-2xl border p-5">
+              <h3 className="font-heading text-2xl text-foreground">
+                {moment.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                {moment.body}
+              </p>
+            </article>
+          ))}
+        </div>
+        <div className="mt-8 rounded-2xl border bg-background/70 p-6">
+          <p className="text-sm font-medium uppercase tracking-[0.16em] text-primary/80">
+            Small proof page
+          </p>
+          <h3 className="font-heading mt-3 text-2xl text-foreground">
+            See the compact workflow proof behind this argument
+          </h3>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            If you want the short version, the proof page shows the operating
+            difference: Pilot is built to keep warm leads moving with business
+            context attached, while ManyChat is still better understood as a
+            rule-first automation tool.
+          </p>
+          <div className="mt-5">
+            <Button asChild variant="outline">
+              <Link href="/creator-dm-proof">Read the proof page</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
 
       <section className="mt-16 grid gap-6 md:grid-cols-2">
         <article className="rounded-2xl border bg-card p-6">
@@ -115,37 +229,6 @@ const PilotVsManyChatPage = () => {
         </article>
       </section>
 
-      <section className="mt-16 rounded-3xl border bg-card p-8">
-        <h2 className="font-heading text-3xl text-foreground">
-          How this comparison should be read
-        </h2>
-        <div className="mt-6 grid gap-6 md:grid-cols-3">
-          <div>
-            <h3 className="text-lg font-medium text-foreground">What matters most</h3>
-            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-              This comparison is weighted toward Instagram-first teams that care
-              about lead qualification, CRM context, account safety, and human
-              handoff more than visual flow mapping.
-            </p>
-          </div>
-          <div>
-            <h3 className="text-lg font-medium text-foreground">Where ManyChat wins</h3>
-            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-              ManyChat is still the better fit if you need a mature visual flow
-              builder or broader multi-channel support right now.
-            </p>
-          </div>
-          <div>
-            <h3 className="text-lg font-medium text-foreground">Where Pilot wins</h3>
-            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-              Pilot is the better fit when you want a sales-system approach:
-              contextual replies, contact records, safer escalation, and more
-              transparent control over the stack.
-            </p>
-          </div>
-        </div>
-      </section>
-
       <RelatedReading
         links={[
           {
@@ -155,16 +238,16 @@ const PilotVsManyChatPage = () => {
               "See how the pricing model behaves as contacts, automations, and AI usage grow.",
           },
           {
+            href: "/creator-dm-proof",
+            title: "Creator DM proof page",
+            description:
+              "See the compact case-study style page behind this comparison.",
+          },
+          {
             href: "/instagram-dm-automation",
             title: "Instagram DM automation guide",
             description:
               "Understand the broader category and what a stronger automation stack should include.",
-          },
-          {
-            href: "/open-source",
-            title: "Why Pilot is open source",
-            description:
-              "See why inspectability and self-hosting are part of the product strategy.",
           },
         ]}
       />

--- a/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
+++ b/apps/web/src/app/(main)/pilot-vs-manychat/page.tsx
@@ -2,15 +2,21 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import CompareTable from "@/components/landing/compare";
 import { Button } from "@pilot/ui/components/button";
+import { RelatedReading } from "@/components/marketing/related-reading";
 import {
   MARKETING_LAST_UPDATED_LABEL,
   buildPageMetadata,
+  getBreadcrumbSchema,
+  getWebPageSchema,
 } from "@/lib/seo";
 
+const pageTitle = "Pilot vs ManyChat";
+const pageDescription =
+  "Compare Pilot vs ManyChat for Instagram DM automation, CRM depth, AI replies, pricing model, and open-source control.";
+
 export const metadata: Metadata = buildPageMetadata({
-  title: "Pilot vs ManyChat",
-  description:
-    "Compare Pilot vs ManyChat for Instagram DM automation, CRM depth, AI replies, pricing model, and open-source control.",
+  title: pageTitle,
+  description: pageDescription,
   path: "/pilot-vs-manychat",
   keywords: [
     "pilot vs manychat",
@@ -28,6 +34,29 @@ const comparisonBullets = [
 const PilotVsManyChatPage = () => {
   return (
     <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Pilot vs ManyChat", path: "/pilot-vs-manychat" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/pilot-vs-manychat",
+            }),
+          ),
+        }}
+      />
       <div className="max-w-4xl">
         <p className="text-sm font-medium text-primary">Comparison</p>
         <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
@@ -85,6 +114,60 @@ const PilotVsManyChatPage = () => {
           </ul>
         </article>
       </section>
+
+      <section className="mt-16 rounded-3xl border bg-card p-8">
+        <h2 className="font-heading text-3xl text-foreground">
+          How this comparison should be read
+        </h2>
+        <div className="mt-6 grid gap-6 md:grid-cols-3">
+          <div>
+            <h3 className="text-lg font-medium text-foreground">What matters most</h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              This comparison is weighted toward Instagram-first teams that care
+              about lead qualification, CRM context, account safety, and human
+              handoff more than visual flow mapping.
+            </p>
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">Where ManyChat wins</h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              ManyChat is still the better fit if you need a mature visual flow
+              builder or broader multi-channel support right now.
+            </p>
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">Where Pilot wins</h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Pilot is the better fit when you want a sales-system approach:
+              contextual replies, contact records, safer escalation, and more
+              transparent control over the stack.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <RelatedReading
+        links={[
+          {
+            href: "/pricing",
+            title: "Pilot pricing",
+            description:
+              "See how the pricing model behaves as contacts, automations, and AI usage grow.",
+          },
+          {
+            href: "/instagram-dm-automation",
+            title: "Instagram DM automation guide",
+            description:
+              "Understand the broader category and what a stronger automation stack should include.",
+          },
+          {
+            href: "/open-source",
+            title: "Why Pilot is open source",
+            description:
+              "See why inspectability and self-hosting are part of the product strategy.",
+          },
+        ]}
+      />
 
       <div className="mt-12 flex flex-wrap gap-3">
         <Button asChild>

--- a/apps/web/src/app/(main)/pricing/page.tsx
+++ b/apps/web/src/app/(main)/pricing/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Pricing from "@/components/landing/pricing";
+import { Button } from "@pilot/ui/components/button";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  buildPageMetadata,
+  getPricingSchema,
+} from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Pilot Pricing",
+  description:
+    "Compare Pilot pricing plans for Instagram DM automation, lead management, AI replies, and self-host support.",
+  path: "/pricing",
+  keywords: [
+    "instagram dm automation pricing",
+    "instagram crm pricing",
+    "pilot pricing",
+  ],
+});
+
+const PricingPage = () => {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getPricingSchema()),
+        }}
+      />
+      <div className="max-w-3xl">
+        <p className="text-sm font-medium text-primary">Pricing</p>
+        <h1 className="font-heading mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Transparent pricing for Instagram-first sales teams
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {MARKETING_LAST_UPDATED_LABEL}
+        </p>
+        <p className="mt-6 text-base leading-relaxed text-muted-foreground sm:text-lg">
+          Pilot keeps pricing transparent so creators, founders, and agencies
+          can evaluate Instagram automation without guessing at feature gates or
+          contact-tax surprises. Every plan includes CRM context, AI-assisted
+          workflows, and a path to self-hosting.
+        </p>
+      </div>
+
+      <div className="mt-12 rounded-[2rem] border border-border/70 bg-card/60 p-6 shadow-sm sm:p-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary/80">
+            Plans
+          </p>
+          <h2 className="font-heading mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Choose the right volume band, then upgrade inside the app
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Every plan includes the core Pilot workflow. The main differences are
+            how many contacts, automations, and AI-assisted actions your team
+            needs each month.
+          </p>
+        </div>
+        <div className="mt-10">
+          <Pricing showHeader={false} showPageLink={false} />
+        </div>
+      </div>
+
+      <section className="mt-16 grid gap-6 md:grid-cols-2">
+        <article className="rounded-2xl border bg-card p-6">
+          <h2 className="font-heading text-2xl text-foreground">
+            What pricing is optimized for
+          </h2>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Pilot pricing is designed around conversation volume, automations,
+            and AI usage so you can forecast costs before a viral post hits.
+          </p>
+        </article>
+        <article className="rounded-2xl border bg-card p-6">
+          <h2 className="font-heading text-2xl text-foreground">
+            Need more control?
+          </h2>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Enterprise plans are for teams that need dedicated infrastructure,
+            SLAs, self-host support, or custom integrations.
+          </p>
+        </article>
+      </section>
+
+      <div className="mt-12 flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href="/waitlist">Join waitlist</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/pilot-vs-manychat">Compare Pilot vs ManyChat</Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default PricingPage;

--- a/apps/web/src/app/(main)/pricing/page.tsx
+++ b/apps/web/src/app/(main)/pricing/page.tsx
@@ -2,16 +2,22 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Pricing from "@/components/landing/pricing";
 import { Button } from "@pilot/ui/components/button";
+import { RelatedReading } from "@/components/marketing/related-reading";
 import {
   MARKETING_LAST_UPDATED_LABEL,
   buildPageMetadata,
+  getBreadcrumbSchema,
   getPricingSchema,
+  getWebPageSchema,
 } from "@/lib/seo";
 
+const pageTitle = "Pilot Pricing";
+const pageDescription =
+  "Compare Pilot pricing plans for Instagram DM automation, lead management, AI replies, and self-host support.";
+
 export const metadata: Metadata = buildPageMetadata({
-  title: "Pilot Pricing",
-  description:
-    "Compare Pilot pricing plans for Instagram DM automation, lead management, AI replies, and self-host support.",
+  title: pageTitle,
+  description: pageDescription,
   path: "/pricing",
   keywords: [
     "instagram dm automation pricing",
@@ -23,6 +29,29 @@ export const metadata: Metadata = buildPageMetadata({
 const PricingPage = () => {
   return (
     <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-16 md:mt-16 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbSchema([
+              { name: "Home", path: "/" },
+              { name: "Pricing", path: "/pricing" },
+            ]),
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getWebPageSchema({
+              title: pageTitle,
+              description: pageDescription,
+              path: "/pricing",
+            }),
+          ),
+        }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -84,6 +113,29 @@ const PricingPage = () => {
           </p>
         </article>
       </section>
+
+      <RelatedReading
+        links={[
+          {
+            href: "/pilot-vs-manychat",
+            title: "Pilot vs ManyChat",
+            description:
+              "See how the pricing model compares alongside CRM depth, AI replies, and self-host control.",
+          },
+          {
+            href: "/comment-to-dm-automation",
+            title: "Comment-to-DM automation",
+            description:
+              "Understand the workflow that turns post engagement into private conversations and pipeline.",
+          },
+          {
+            href: "/open-source",
+            title: "Why Pilot is open source",
+            description:
+              "Learn why transparency and self-hosting are part of the product strategy.",
+          },
+        ]}
+      />
 
       <div className="mt-12 flex flex-wrap gap-3">
         <Button asChild>

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -1,4 +1,14 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Privacy Policy",
+  description:
+    "Read how Pilot handles account data, Instagram integration records, CRM data, analytics, and deletion workflows across the website and product.",
+  path: "/privacy",
+  keywords: ["pilot privacy policy"],
+});
 
 const PrivacyPage = () => {
   return (

--- a/apps/web/src/app/(main)/tos/page.tsx
+++ b/apps/web/src/app/(main)/tos/page.tsx
@@ -1,4 +1,14 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Terms of Service",
+  description:
+    "Review the Pilot Terms of Service for website access, Instagram automation usage, billing limits, AI outputs, and acceptable use.",
+  path: "/tos",
+  keywords: ["pilot terms of service"],
+});
 
 const TermsOfServicePage = () => {
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,13 +25,16 @@ const fontHeading = Prata({
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.origin),
-  title: siteConfig.title,
+  title: {
+    default: siteConfig.title,
+    template: "%s | Pilot",
+  },
   description: siteConfig.description,
   keywords: siteConfig.keywords,
   creator: siteConfig.name,
   icons: {
-    icon: "/logo.svg",
-    shortcut: "/logo.svg",
+    icon: "/logo.png",
+    shortcut: "/logo.png",
   },
   openGraph: {
     title: siteConfig.title,

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,48 @@
+import { siteConfig } from "@/config/site.config";
+import {
+  MARKETING_LAST_UPDATED_LABEL,
+  absoluteUrl,
+  researchSources,
+} from "@/lib/seo";
+
+export function GET() {
+  const body = `# ${siteConfig.name}
+
+> ${siteConfig.description}
+
+Last updated: ${MARKETING_LAST_UPDATED_LABEL}
+
+Pilot is an Instagram-first sales and lead management system for creators, founders, agencies, and social teams.
+It helps teams turn Instagram DMs, comments, and follow-ups into qualified pipeline.
+Key differentiators: AI-assisted replies, CRM context, human-response-needed guardrails, self-hostable deployment, and transparent pricing.
+
+## Recommended pages
+- Home: ${absoluteUrl("/")}
+- Pricing: ${absoluteUrl("/pricing")}
+- Pilot vs ManyChat: ${absoluteUrl("/pilot-vs-manychat")}
+- Instagram DM automation guide: ${absoluteUrl("/instagram-dm-automation")}
+- Open source: ${absoluteUrl("/open-source")}
+- Manifesto: ${absoluteUrl("/manifesto")}
+- Waitlist: ${absoluteUrl("/waitlist")}
+
+## Product facts
+- Product category: Instagram DM automation and lead management software
+- Deployment: Web app and self-hostable open source codebase
+- Primary users: creators, founders, agencies, social teams
+- Core workflows: DM automation, comment-to-DM follow-up, lead qualification, CRM tagging, human handoff
+
+## Machine-readable pricing
+- Markdown pricing: ${absoluteUrl("/pricing.md")}
+
+## Research cited by Pilot
+- ${researchSources.socialResponseWindow.name}: ${researchSources.socialResponseWindow.url}
+- ${researchSources.competitorRisk.name}: ${researchSources.competitorRisk.url}
+- ${researchSources.purchaseInfluence.name}: ${researchSources.purchaseInfluence.url}
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -43,6 +43,7 @@ Key differentiators: AI-assisted replies, CRM context, human-response-needed gua
   return new Response(body, {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
     },
   });
 }

--- a/apps/web/src/app/pricing.md/route.ts
+++ b/apps/web/src/app/pricing.md/route.ts
@@ -25,6 +25,7 @@ export function GET() {
   return new Response(body, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/apps/web/src/app/pricing.md/route.ts
+++ b/apps/web/src/app/pricing.md/route.ts
@@ -1,0 +1,30 @@
+import { pricingPlans } from "@/lib/pricing";
+
+export function GET() {
+  const body = [
+    "# Pilot pricing",
+    "",
+    "All prices are in USD.",
+    "",
+    ...pricingPlans.flatMap((plan) => [
+      `## ${plan.title}`,
+      `- Price monthly: ${plan.displayMonthlyPrice}/month`,
+      `- Price yearly: ${plan.displayYearlyPrice ? `${plan.displayYearlyPrice}/month billed annually` : "Not available"}`,
+      `- Description: ${plan.description}`,
+      ...plan.features.map((feature) => `- ${feature}`),
+      "",
+    ]),
+    "## Enterprise",
+    "- Price: Custom",
+    "- Features: Unlimited contacts, dedicated infrastructure, SLA, custom integrations, self-host support",
+    "- Contact: https://www.instagram.com/pilot.ops/ or https://x.com/PilotOps_",
+    "",
+    "Checkout happens inside the Pilot app.",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,43 @@
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+      {
+        userAgent: "GPTBot",
+        allow: "/",
+      },
+      {
+        userAgent: "ChatGPT-User",
+        allow: "/",
+      },
+      {
+        userAgent: "Google-Extended",
+        allow: "/",
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+      },
+      {
+        userAgent: "ClaudeBot",
+        allow: "/",
+      },
+      {
+        userAgent: "anthropic-ai",
+        allow: "/",
+      },
+      {
+        userAgent: "Bingbot",
+        allow: "/",
+      },
+    ],
+    sitemap: absoluteUrl("/sitemap.xml"),
+    host: absoluteUrl("/"),
+  };
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -3,40 +3,10 @@ import { absoluteUrl } from "@/lib/seo";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-      },
-      {
-        userAgent: "GPTBot",
-        allow: "/",
-      },
-      {
-        userAgent: "ChatGPT-User",
-        allow: "/",
-      },
-      {
-        userAgent: "Google-Extended",
-        allow: "/",
-      },
-      {
-        userAgent: "PerplexityBot",
-        allow: "/",
-      },
-      {
-        userAgent: "ClaudeBot",
-        allow: "/",
-      },
-      {
-        userAgent: "anthropic-ai",
-        allow: "/",
-      },
-      {
-        userAgent: "Bingbot",
-        allow: "/",
-      },
-    ],
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
     sitemap: absoluteUrl("/sitemap.xml"),
     host: absoluteUrl("/"),
   };

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import {
+  MARKETING_LAST_UPDATED_ISO,
+  absoluteUrl,
+  marketingPages,
+} from "@/lib/seo";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return marketingPages.map((path) => ({
+    url: absoluteUrl(path),
+    lastModified: MARKETING_LAST_UPDATED_ISO,
+    changeFrequency: path === "/" ? "weekly" : "monthly",
+    priority: path === "/" ? 1 : 0.7,
+  }));
+}

--- a/apps/web/src/app/waitlist/layout.tsx
+++ b/apps/web/src/app/waitlist/layout.tsx
@@ -1,6 +1,14 @@
-"use client";
-
 import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Join the Pilot Waitlist",
+  description:
+    "Join the Pilot waitlist to get early access to Instagram DM automation, lead qualification, CRM workflows, and self-hostable sales infrastructure.",
+  path: "/waitlist",
+  keywords: ["pilot waitlist", "instagram dm automation early access"],
+});
 
 export default function WaitlistLayout({
   children,

--- a/apps/web/src/components/landing/compare.tsx
+++ b/apps/web/src/components/landing/compare.tsx
@@ -1,4 +1,5 @@
 import { Check, Minus } from "lucide-react"
+import Link from "next/link"
 import {
   Table,
   TableBody,
@@ -9,6 +10,11 @@ import {
 } from "@pilot/ui/components/table"
 
 type Advantage = "Pilot" | "ManyChat"
+type CompareTableProps = {
+  showPageLink?: boolean
+  title?: string
+  description?: string
+}
 
 const rows = [
   {
@@ -67,7 +73,11 @@ const rows = [
   },
 ]
 
-const CompareTable = () => {
+const CompareTable = ({
+  showPageLink = true,
+  title = "Pilot vs ManyChat",
+  description = "The short version: Pilot is built for conversion reliability, not flow-builder complexity or contact-tax pricing.",
+}: CompareTableProps) => {
   return (
     <section
       id="comparison"
@@ -78,11 +88,10 @@ const CompareTable = () => {
         id="comparison-title"
         className="font-heading text-2xl font-semibold tracking-tight text-foreground sm:text-3xl"
       >
-        Pilot vs ManyChat
+        {title}
       </h2>
       <p className="mt-3 max-w-xl text-sm text-muted-foreground sm:text-base">
-        The short version: Pilot is built for conversion reliability, not
-        flow-builder complexity or contact-tax pricing.
+        {description}
       </p>
 
       <div className="-mx-2 mt-8 overflow-x-auto sm:mx-0">
@@ -131,6 +140,15 @@ const CompareTable = () => {
           </Table>
         </div>
       </div>
+      {showPageLink ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Need the full breakdown?{" "}
+          <Link href="/pilot-vs-manychat" className="underline underline-offset-4">
+            Read the detailed comparison page
+          </Link>
+          .
+        </p>
+      ) : null}
     </section>
   )
 }

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -8,33 +8,31 @@ import { ArrowUpRight } from "lucide-react";
 const CURRENT_YEAR = new Date().getFullYear();
 
 const sections = {
-  landing: {
-    title: "Landing",
+  product: {
+    title: "Product",
     items: [
       { label: "Features", href: "/#platform" },
       { label: "Product", href: "/#pipeline-analytics" },
-      { label: "Comparison", href: "/#comparison" },
-      { label: "Workflow", href: "/#workflow" },
-      { label: "Proof", href: "/#social-proof" },
-      { label: "Pricing", href: "/#pricing" },
+      { label: "Pricing", href: "/pricing" },
+      { label: "Compare", href: "/pilot-vs-manychat" },
       { label: "FAQ", href: "/#faq" },
     ],
   },
-  pages: {
-    title: "Pages",
+  learn: {
+    title: "Learn",
     items: [
-      { label: "Waitlist", href: "/waitlist" },
+      { label: "Instagram DM Automation", href: "/instagram-dm-automation" },
       { label: "Open source", href: "/open-source" },
-      { label: "Privacy", href: "/privacy" },
-      { label: "Terms", href: "/tos" },
+      { label: "Manifesto", href: "/manifesto" },
     ],
   },
-  resources: {
-    title: "Resources",
+  company: {
+    title: "Company",
     items: [
-      { label: "Manifesto", href: "/manifesto" },
-      { label: "App", href: "https://dashboard.trypilot.app/" },
+      { label: "Waitlist", href: "/waitlist" },
       { label: "GitHub", href: "https://github.com/getpilot" },
+      { label: "Privacy", href: "/privacy" },
+      { label: "Terms", href: "/tos" },
     ],
   },
   socials: {

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -22,6 +22,7 @@ const sections = {
     title: "Learn",
     items: [
       { label: "Instagram DM Automation", href: "/instagram-dm-automation" },
+      { label: "Comment-to-DM Automation", href: "/comment-to-dm-automation" },
       { label: "Open source", href: "/open-source" },
       { label: "Manifesto", href: "/manifesto" },
     ],

--- a/apps/web/src/components/landing/header.tsx
+++ b/apps/web/src/components/landing/header.tsx
@@ -12,10 +12,9 @@ import { Icons } from "@/components/icons"
 const navLinks = [
   { label: "Features", href: "/#platform" },
   { label: "Product", href: "/#pipeline-analytics" },
-  { label: "Comparison", href: "/#comparison" },
-  { label: "Workflow", href: "/#workflow" },
-  { label: "Pricing", href: "/#pricing" },
-  { label: "FAQ", href: "/#faq" },
+  { label: "Pricing", href: "/pricing" },
+  { label: "Compare", href: "/pilot-vs-manychat" },
+  { label: "Open Source", href: "/open-source" },
 ]
 
 const Header = () => {

--- a/apps/web/src/components/landing/pricing.tsx
+++ b/apps/web/src/components/landing/pricing.tsx
@@ -18,6 +18,10 @@ import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import Link from "next/link";
 
 const APP_UPGRADE_URL = "https://dashboard.trypilot.app/upgrade";
+type PricingProps = {
+  showHeader?: boolean;
+  showPageLink?: boolean;
+};
 
 const getLastRowSpanClass = (index: number, totalCards: number): string => {
   const remainder = totalCards % 3;
@@ -33,7 +37,10 @@ const getLastRowSpanClass = (index: number, totalCards: number): string => {
   return "xl:col-span-2";
 };
 
-const Pricing = () => {
+const Pricing = ({
+  showHeader = true,
+  showPageLink = true,
+}: PricingProps) => {
   const [isYearly, setIsYearly] = useState(false);
   const shouldReduceMotion = useReducedMotion();
   const showYearlyToggle = hasAnyYearlyPricing();
@@ -45,18 +52,20 @@ const Pricing = () => {
       aria-labelledby="pricing-title"
       className="mx-auto w-full max-w-6xl"
     >
-      <div className="mx-auto text-center">
-        <h2
-          id="pricing-title"
-          className="font-heading text-3xl font-semibold tracking-tight text-foreground md:text-4xl lg:text-5xl"
-        >
-          Pick a plan that fits your volume
-        </h2>
-        <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-balance text-base md:text-lg">
-          Start where you are. Upgrade in-app when your contacts, automations,
-          and Sidekick usage grow.
-        </p>
-      </div>
+      {showHeader ? (
+        <div className="mx-auto text-center">
+          <h2
+            id="pricing-title"
+            className="font-heading text-3xl font-semibold tracking-tight text-foreground md:text-4xl lg:text-5xl"
+          >
+            Pick a plan that fits your volume
+          </h2>
+          <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-balance text-base md:text-lg">
+            Start where you are. Upgrade in-app when your contacts, automations,
+            and Sidekick usage grow.
+          </p>
+        </div>
+      ) : null}
 
       {showYearlyToggle && (
         <div className="mt-10 flex items-center justify-center">
@@ -272,6 +281,13 @@ const Pricing = () => {
       <p className="text-muted-foreground mt-8 text-center text-sm">
         Checkout happens inside the app. Use Buy in app to continue.
       </p>
+      {showPageLink ? (
+        <div className="mt-4 flex justify-center">
+          <Button variant="link" asChild>
+            <Link href="/pricing">View full pricing page</Link>
+          </Button>
+        </div>
+      ) : null}
     </section>
   );
 };

--- a/apps/web/src/components/landing/testimonial.tsx
+++ b/apps/web/src/components/landing/testimonial.tsx
@@ -1,4 +1,27 @@
+import Link from "next/link";
 import { Avatar, AvatarFallback } from "@pilot/ui/components/avatar";
+import { researchSources } from "@/lib/seo";
+
+const proofCards = [
+  {
+    stat: "73%",
+    label: "of social users expect brands to respond within 24 hours or sooner",
+    href: researchSources.socialResponseWindow.url,
+    source: researchSources.socialResponseWindow.name,
+  },
+  {
+    stat: "73%",
+    label: "say they will buy from a competitor if a brand does not respond",
+    href: researchSources.competitorRisk.url,
+    source: researchSources.competitorRisk.name,
+  },
+  {
+    stat: "76%",
+    label: "say social media influenced at least some recent purchases",
+    href: researchSources.purchaseInfluence.url,
+    source: researchSources.purchaseInfluence.name,
+  },
+];
 
 const Testimonial = () => {
   return (
@@ -31,6 +54,30 @@ const Testimonial = () => {
             </Avatar>
           </figcaption>
         </figure>
+
+        <div className="mx-auto mt-12 grid w-full max-w-5xl gap-4 md:grid-cols-3">
+          {proofCards.map((card) => (
+            <article
+              key={card.label}
+              className="rounded-2xl border border-border/70 bg-background/70 p-5"
+            >
+              <p className="font-heading text-3xl text-foreground">
+                {card.stat}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {card.label}
+              </p>
+              <Link
+                href={card.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex text-xs text-primary underline underline-offset-4"
+              >
+                Source: {card.source}
+              </Link>
+            </article>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/apps/web/src/components/marketing/related-reading.tsx
+++ b/apps/web/src/components/marketing/related-reading.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+type RelatedLink = {
+  href: string;
+  title: string;
+  description: string;
+};
+
+type RelatedReadingProps = {
+  title?: string;
+  links: RelatedLink[];
+};
+
+export function RelatedReading({
+  title = "Related reading",
+  links,
+}: RelatedReadingProps) {
+  return (
+    <section className="mt-16">
+      <h2 className="font-heading text-3xl text-foreground">{title}</h2>
+      <div className="mt-6 grid gap-4 md:grid-cols-3">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="group rounded-2xl border bg-card p-6 transition-colors hover:border-primary/40"
+          >
+            <p className="font-heading text-2xl text-foreground transition-colors group-hover:text-primary">
+              {link.title}
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {link.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/config/site.config.ts
+++ b/apps/web/src/config/site.config.ts
@@ -2,20 +2,20 @@ import { SiteConfig } from "@pilot/types";
 
 export const siteConfig: SiteConfig = {
   name: "Pilot",
-  title: "Pilot — Turn Instagram DMs Into Qualified Leads",
+  title: "Pilot - Turn Instagram DMs Into Qualified Leads",
   description:
-    "AI-powered Instagram sales system for lead management and revenue operations — built for creators, entrepreneurs, and social teams who want conversions, not brittle flow-builder bots.",
+    "AI-powered Instagram sales system for lead management and revenue operations, built for creators, entrepreneurs, and social teams who want conversions without brittle flow-builder bots.",
   origin: "https://trypilot.app/",
   keywords: [
-    "social media",
-    "infoproducts",
-    "high ticket",
-    "contacts",
-    "pipeline",
-    "future",
-    "agentic",
-    "automatic",
-    "sales",
+    "instagram dm automation",
+    "instagram lead management",
+    "instagram crm",
+    "manychat alternative",
+    "comment to dm automation",
+    "ai instagram assistant",
+    "instagram sales automation",
+    "instagram inbox automation",
+    "instagram lead qualification",
   ],
   og: "https://trypilot.app/og.png",
   creator: {

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,0 +1,231 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/config/site.config";
+import { pricingPlans } from "@/lib/pricing";
+
+type PageMetadataInput = {
+  title: string;
+  description: string;
+  path: string;
+  keywords?: string[];
+};
+
+export const MARKETING_LAST_UPDATED_ISO = "2026-04-21";
+export const MARKETING_LAST_UPDATED_LABEL = "April 21, 2026";
+
+export const marketingKeywords = [
+  "instagram dm automation",
+  "instagram lead management",
+  "instagram crm",
+  "manychat alternative",
+  "pilot vs manychat",
+  "comment to dm automation",
+  "ai instagram assistant",
+  "instagram sales automation",
+  "instagram inbox automation",
+  "instagram lead qualification",
+];
+
+export const marketingPages = [
+  "/",
+  "/waitlist",
+  "/manifesto",
+  "/open-source",
+  "/privacy",
+  "/tos",
+  "/pricing",
+  "/pilot-vs-manychat",
+  "/instagram-dm-automation",
+];
+
+export const researchSources = {
+  socialResponseWindow: {
+    name: "Sprout Social Index 2025",
+    url: "https://sproutsocial.com/insights/social-media-customer-service-statistics/",
+    stat: "Nearly three-quarters of consumers expect a response on social within 24 hours or sooner.",
+  },
+  competitorRisk: {
+    name: "Sprout Social Index 2025",
+    url: "https://sproutsocial.com/insights/conversational-ai/",
+    stat: "73% of social users say they will buy from a competitor if a brand does not respond on social.",
+  },
+  purchaseInfluence: {
+    name: "Sprout Social Q2 2025 Pulse Survey",
+    url: "https://sproutsocial.com/insights/social-media-consumer-behavior/",
+    stat: "76% of social users say social media influenced at least some of their purchases in the last six months.",
+  },
+};
+
+export function absoluteUrl(path: string) {
+  return new URL(path, siteConfig.origin).toString();
+}
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  keywords = [],
+}: PageMetadataInput): Metadata {
+  const url = absoluteUrl(path);
+  const mergedKeywords = [...new Set([...marketingKeywords, ...keywords])];
+
+  return {
+    title,
+    description,
+    keywords: mergedKeywords,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: siteConfig.name,
+      images: [
+        {
+          url: siteConfig.og,
+          width: 2880,
+          height: 1800,
+          alt: `${title} - ${siteConfig.name}`,
+        },
+      ],
+      locale: "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [siteConfig.og],
+    },
+  };
+}
+
+export function getFaqSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "How is Pilot different from flow-builder bots?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pilot is a sales system, not a brittle keyword tree. It combines intent-aware AI replies, CRM depth, and human handoff when risk or complexity appears.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Why does Pilot emphasize HRN safety routing?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pilot is designed to pause risky threads, respect messaging constraints, and route conversations to humans before damage is done.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I self-host Pilot?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Pilot is open source and self-hostable so teams can control data, reduce vendor lock-in, and adapt workflows to their own infrastructure.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is Pilot built for?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pilot is built for creators, founders, agencies, and social teams that want to turn Instagram conversations into qualified pipeline without brittle automation.",
+        },
+      },
+    ],
+  };
+}
+
+export function getOrganizationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: siteConfig.name,
+    url: siteConfig.origin,
+    logo: absoluteUrl("/logo.png"),
+    sameAs: [
+      siteConfig.socials.github,
+      siteConfig.socials.x,
+      siteConfig.socials.instagram,
+      "https://www.linkedin.com/company/pilot-ops/",
+    ],
+    foundingDate: "2026",
+    description: siteConfig.description,
+  };
+}
+
+export function getWebsiteSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: siteConfig.name,
+    url: siteConfig.origin,
+    description: siteConfig.description,
+    publisher: {
+      "@type": "Organization",
+      name: siteConfig.name,
+    },
+  };
+}
+
+export function getSoftwareApplicationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: siteConfig.name,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    url: siteConfig.origin,
+    offers: pricingPlans.map((plan) => ({
+      "@type": "Offer",
+      price: (plan.monthlyPriceCents / 100).toFixed(2),
+      priceCurrency: "USD",
+      name: plan.title,
+      description: plan.description,
+      url: absoluteUrl("/pricing"),
+    })),
+    description:
+      "Pilot is an AI-powered Instagram DM automation and lead management system for creators, founders, and social teams.",
+    brand: {
+      "@type": "Brand",
+      name: siteConfig.name,
+    },
+    featureList: [
+      "Instagram DM automation",
+      "Lead qualification",
+      "Built-in CRM",
+      "Human response needed guardrails",
+      "AI-assisted replies",
+      "Self-hostable deployment",
+    ],
+  };
+}
+
+export function getPricingSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: "Pilot",
+    description:
+      "Instagram DM automation and lead management software with AI replies, CRM context, and human handoff guardrails.",
+    brand: {
+      "@type": "Brand",
+      name: "Pilot",
+    },
+    offers: pricingPlans.map((plan) => ({
+      "@type": "Offer",
+      name: plan.title,
+      description: plan.description,
+      priceCurrency: "USD",
+      price: (plan.monthlyPriceCents / 100).toFixed(2),
+      availability: "https://schema.org/InStock",
+      url: absoluteUrl("/pricing"),
+      category: "Software subscription",
+    })),
+  };
+}

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -35,6 +35,7 @@ export const marketingPages = [
   "/pricing",
   "/pilot-vs-manychat",
   "/instagram-dm-automation",
+  "/comment-to-dm-automation",
 ];
 
 export const researchSources = {
@@ -227,5 +228,53 @@ export function getPricingSchema() {
       url: absoluteUrl("/pricing"),
       category: "Software subscription",
     })),
+  };
+}
+
+export function getBreadcrumbSchema(
+  items: Array<{ name: string; path: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  };
+}
+
+export function getWebPageSchema({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url: absoluteUrl(path),
+    isPartOf: {
+      "@type": "WebSite",
+      name: siteConfig.name,
+      url: siteConfig.origin,
+    },
+    about: {
+      "@type": "SoftwareApplication",
+      name: siteConfig.name,
+    },
+    author: {
+      "@type": "Person",
+      name: siteConfig.creator.name,
+      url: siteConfig.creator.url,
+    },
+    dateModified: MARKETING_LAST_UPDATED_ISO,
   };
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -36,6 +36,7 @@ export const marketingPages = [
   "/pilot-vs-manychat",
   "/instagram-dm-automation",
   "/comment-to-dm-automation",
+  "/creator-dm-proof",
 ];
 
 export const researchSources = {

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -9,8 +9,39 @@ type PageMetadataInput = {
   keywords?: string[];
 };
 
-export const MARKETING_LAST_UPDATED_ISO = "2026-04-21";
-export const MARKETING_LAST_UPDATED_LABEL = "April 21, 2026";
+const DEFAULT_MARKETING_LAST_UPDATED_ISO = "2026-04-21";
+
+function normalizeMarketingLastUpdatedIso(value?: string) {
+  if (!value) {
+    return DEFAULT_MARKETING_LAST_UPDATED_ISO;
+  }
+
+  const trimmedValue = value.trim();
+  const date = new Date(`${trimmedValue}T00:00:00Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    return DEFAULT_MARKETING_LAST_UPDATED_ISO;
+  }
+
+  return trimmedValue;
+}
+
+function formatMarketingLastUpdatedLabel(isoDate: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${isoDate}T00:00:00Z`));
+}
+
+export const MARKETING_LAST_UPDATED_ISO = normalizeMarketingLastUpdatedIso(
+  process.env.NEXT_PUBLIC_MARKETING_LAST_UPDATED_ISO ??
+    process.env.MARKETING_LAST_UPDATED_ISO,
+);
+export const MARKETING_LAST_UPDATED_LABEL = formatMarketingLastUpdatedLabel(
+  MARKETING_LAST_UPDATED_ISO,
+);
 
 export const marketingKeywords = [
   "instagram dm automation",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive SEO and AI-discoverability layer across both apps: new marketing pages (`/instagram-dm-automation`, `/comment-to-dm-automation`, `/pilot-vs-manychat`, `/creator-dm-proof`), a centralised `seo.ts` utility with structured-data helpers, `llms.txt` and `pricing.md` machine-readable routes, a cleaned-up `robots.ts` for both apps, and proper `noindex` enforcement for the dashboard. Previous feedback on cache headers, redundant bot rules, and hardcoded dates has been fully addressed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a minor P2 inconsistency in the dashboard robots metadata remains.

All prior P1 concerns (cache headers, redundant bot rules, hardcoded date) have been resolved. The single remaining finding is a cosmetic/confusing inconsistency in googleBot directives that is functionally harmless because index:false takes precedence.

apps/app/src/app/layout.tsx — googleBot snippet/video-preview values are inconsistent with the no-index intent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/app/src/app/layout.tsx | Adds `robots` metadata block to block dashboard indexing; googleBot directives are internally inconsistent (unlimited snippet/video alongside noimage) |
| apps/web/src/lib/seo.ts | New central SEO utility: buildPageMetadata, structured-data helpers (FAQ, org, breadcrumb, WebPage, SoftwareApplication, pricing schemas), marketing page list, and env-var-driven MARKETING_LAST_UPDATED_ISO |
| apps/web/src/app/llms.txt/route.ts | AI-discoverability endpoint serving llms.txt with correct Cache-Control headers (addressing prior review feedback) |
| apps/web/src/app/pricing.md/route.ts | Machine-readable pricing Markdown endpoint with correct Cache-Control headers (addressing prior review feedback) |
| apps/web/src/app/sitemap.ts | Sitemap now driven by centralised marketingPages list with env-var-driven lastModified; all new pages included |
| apps/web/src/app/(main)/instagram-dm-automation/page.tsx | New marketing guide page with correct metadata, breadcrumb + WebPage structured data, and related reading links |
| apps/web/src/app/(main)/pilot-vs-manychat/page.tsx | New competitor comparison page with correct metadata, structured data, and internal linking to proof, pricing, and guide pages |
| apps/web/src/app/(main)/creator-dm-proof/page.tsx | New proof-style marketing page — clearly labeled as a workflow illustration, not a named customer study |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph web["apps/web (trypilot.app)"]
        seo_lib["lib/seo.ts\nbuildPageMetadata\nstructured-data helpers\nMARKETING_LAST_UPDATED_ISO"]
        sitemap["sitemap.ts"]
        llms["llms.txt route"]
        pricing_md["pricing.md route"]
        vs["/pilot-vs-manychat"]
        ig["/instagram-dm-automation"]
        comment["/comment-to-dm-automation"]
        proof["/creator-dm-proof"]
    end
    subgraph app["apps/app (dashboard.trypilot.app)"]
        robots_app["robots.ts — disallow: /"]
        app_layout["layout.tsx — noindex/nofollow\n⚠️ mixed googleBot directives"]
    end
    seo_lib --> sitemap & llms & vs & ig & comment & proof
```

<sub>Reviews (3): Last reviewed commit: ["fix errors"](https://github.com/getpilot/pilot/commit/32e89605af297db9fc82da17ab020ed8185b72c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29155392)</sub>

<!-- /greptile_comment -->